### PR TITLE
Issue #69 : Added PnP PowerShell equivalent to replace owner in M365 group.

### DIFF
--- a/scripts/aad-replace-owner-with-a-different-one/README.md
+++ b/scripts/aad-replace-owner-with-a-different-one/README.md
@@ -137,6 +137,7 @@ Disconnect-PnPOnline
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
+
 ## Source Credit
 
 Sample first appeared on [Replace an owner in a Microsoft 365 Group or Microsoft Team | CLI for Microsoft 365](https://pnp.github.io/cli-microsoft365/sample-scripts/aad/replace-owner-with-a-different-one/)
@@ -147,6 +148,7 @@ Sample first appeared on [Replace an owner in a Microsoft 365 Group or Microsoft
 |-----------|
 | Alan Eardley |
 | Patrick Lamber |
+| Reshmee Auckloo |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/aad-replace-owner-with-a-different-one/assets/sample.json
+++ b/scripts/aad-replace-owner-with-a-different-one/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "Replace an owner in a Microsoft 365 Group or Microsoft Team",
     "url": "aad-replace-owner-with-a-different-one/README.html",
     "creationDateTime": "2021-05-04",
-    "updateDateTime": "2021-05-04",
+    "updateDateTime": "2021-10-11",
     "shortDescription": "Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone",
     "longDescription": null,
     "products": [
@@ -26,6 +26,10 @@
       {
         "key": "cli-for-microsoft365",
         "value": "3.7.0"
+      },
+      {
+        "key": "pnp-powerShell",
+        "value": "1.5.0"
       }
     ],
     "thumbnails": [
@@ -38,6 +42,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "reshmee011",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/7693852?v=4",
+        "name": "Reshmee Auckloo"
+      },
       {
         "name": "Patrick Lamber",
         "gitHubAccount": "plamber",

--- a/scripts/teams-list-teams-owners-and-members/README.md
+++ b/scripts/teams-list-teams-owners-and-members/README.md
@@ -95,6 +95,7 @@ Sample first appeared on [List all Microsoft Teams team's Owners and Members | C
 |-----------|
 | Patrick Lamber |
 | Inspired by Robin Clarke |
+| Reshmee Auckloo |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/teams-list-teams-owners-and-members/assets/sample.json
+++ b/scripts/teams-list-teams-owners-and-members/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "List all Microsoft Teams team's Owners and Members",
     "url": "teams-list-teams-owners-and-members/README.html",
     "creationDateTime": "2021-03-20",
-    "updateDateTime": "2021-03-20",
+    "updateDateTime": "2021-10-11",
     "shortDescription": "This script allows you to list all Teams team's owners and members and export them into a CSV file.",
     "longDescription": null,
     "products": [
@@ -24,6 +24,10 @@
       {
         "key": "cli-for-microsoft365",
         "value": "3.7.0"
+      },
+      {
+        "key": "pnp-powerShell",
+        "value": "1.5.0"
       }
     ],
     "thumbnails": [
@@ -36,6 +40,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "reshmee011",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/7693852?v=4",
+        "name": "Reshmee Auckloo"
+      },
       {
         "name": "Patrick Lamber",
         "gitHubAccount": "plamber",


### PR DESCRIPTION
Added PnP PowerShell equivalent to replace owner in M365 group as per Issue #69.
Added PnP PowerShell equivalent to list owners and memebers in teams as per Issue #71 
