### PR TITLE
Add CLI for Microsoft 365 to Add a document library web part to a page (and only show a specific folder)

### DIFF
--- a/scripts/spo-add-document-library-webpart-to-page/README.md
+++ b/scripts/spo-add-document-library-webpart-to-page/README.md
@@ -38,7 +38,6 @@ foreach ($name in $ray) {
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
-***
 
 # [CLI for Microsoft 365 with PowerShell](#tab/cli-m365-ps)
 ```powershell

--- a/scripts/spo-add-document-library-webpart-to-page/README.md
+++ b/scripts/spo-add-document-library-webpart-to-page/README.md
@@ -40,6 +40,42 @@ foreach ($name in $ray) {
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
 
+# [CLI for Microsoft 365 with PowerShell](#tab/cli-m365-ps)
+```powershell
+
+$site = "https://yourtenant.sharepoint.com/sites/Yoursite/"
+
+$m365Status = m365 status
+if ($m365Status -eq "Logged Out") {
+    m365 login
+}
+
+$ray = "folder1",
+       "folder2",
+       "folder3"
+
+foreach ($name in $ray) {
+
+    #create page
+    $fileName = "$name.aspx"
+    m365 spo page add --name $fileName --title $name --webUrl $site
+    
+    #add sections
+    m365 spo page section add --name $fileName --webUrl $site --sectionTemplate TwoColumn --order 1
+    
+    #add text webpart
+    m365 spo page text add --webUrl $site --pageName $fileName --text $name --section 1 --column 1
+    
+    #add doclib
+    $webpartProperties = '{\"selectedListId\":\"DC4B61E0-01BE-4A87-B8E1-B9AEF4E34153\",\"selectedFolderPath\":\"' + $name + '\",\"hideCommandBar\":\"false\"}'
+    m365 spo page clientsidewebpart add --webUrl $site --pageName $fileName --standardWebPart List --section 1 --column 1 --webPartProperties $webpartProperties
+    m365 spo page set --name $fileName --webUrl $site --publish
+}
+
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+***
+
 ## Source Credit
 
 Sample first appeared on [Use PnP Powershell to add a document library webpart to a page (and only show a specific folder) | Tech Community](https://techcommunity.microsoft.com/t5/microsoft-365-pnp-blog/use-pnp-powershell-to-add-a-document-library-webpart-to-a-page/ba-p/2428310)
@@ -49,6 +85,7 @@ Sample first appeared on [Use PnP Powershell to add a document library webpart t
 | Author(s) |
 |-----------|
 | Marijn Somers |
+| [Adam Wójcik](https://github.com/Adam-it)|
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://telemetry.sharepointpnp.com/script-samples/scripts/template-script-submission" aria-hidden="true" />

--- a/scripts/spo-add-document-library-webpart-to-page/assets/sample.json
+++ b/scripts/spo-add-document-library-webpart-to-page/assets/sample.json
@@ -9,7 +9,7 @@
         ""
       ],
       "creationDateTime": "2021-06-18",
-      "updateDateTime": "2021-06-18",
+      "updateDateTime": "2021-11-10",
       "products": [
         "SharePoint"
       ],
@@ -17,6 +17,10 @@
         {
           "key": "pnp-powerShell",
           "value": "1.5.0"
+        },
+        {
+          "key": "cli-for-microsoft365",
+          "value": "6.14.22"
         }
       ],
       "categories": [
@@ -33,6 +37,11 @@
         }
       ],
       "authors": [
+        {
+          "gitHubAccount": "Adam-it",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+          "name": "Adam Wójcik"
+        },
         {
           "gitHubAccount": "Marijnsomers",
           "company": "Mijn 365 Coach",


### PR DESCRIPTION
### 🎯 PR aim
The aim of this PR is to add CLI for Microsoft 365 equivalent -
https://pnp.github.io/script-samples/spo-add-document-library-webpart-to-page/README.html?tabs=pnpps

### ✔ What was done
- [X] updated readme with script
- [X] updated sample.json

### 🔗 Related
#117

### 📸 Result 
The result of running the script compared in m365 CLI
page created

![pagesAdded](https://user-images.githubusercontent.com/58668583/141027148-a9a67a8f-804f-4c31-b51c-773d57232ba1.png)
one of the pages looks like
![pageWithWebpart](https://user-images.githubusercontent.com/58668583/141027157-c9686503-d449-44b9-9638-bc7544f6ef73.png)

