### PR TITLE
Add CLI for Microsoft 365 to Report of Private Teams channels to Excel

### DIFF
--- a/scripts/report-private-teams-excel/README.md
+++ b/scripts/report-private-teams-excel/README.md
@@ -61,9 +61,8 @@ Write-Host "Uploaded Excel File to SharePoint"
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
-***
 
-# [CLI for Microsoft 365](#tab/cli-m365-ps2)
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
 ```powershell
 
 Write-Host "Running Script..."

--- a/scripts/report-private-teams-excel/README.md
+++ b/scripts/report-private-teams-excel/README.md
@@ -63,6 +63,52 @@ Write-Host "Uploaded Excel File to SharePoint"
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
 
+# [CLI for Microsoft 365](#tab/cli-m365-ps2)
+```powershell
+
+Write-Host "Running Script..."
+
+# Ensure login
+$m365Status = m365 status
+if ($m365Status -eq "Logged Out") {
+m365 login
+}
+
+#-----------------
+# Gather Reporting Data
+#-----------------
+
+# Gets all Team Private Channels based on the template
+$teamPrivateChannels = m365 spo site classic list --webTemplate "TEAMCHANNEL#0"
+$teamPrivateChannels = $teamPrivateChannels | ConvertFrom-Json
+    
+#-----------------
+# Produce and Save Reporting Data
+#-----------------
+$now = [System.DateTime]::Now.ToString("yyyy-mm-dd_hh-MM-ss")
+$reportFileName = "teams-private-channels-$($now).xlsx"
+
+$ExcelReportSettings = @{
+    Path          = $reportFileName
+    Title         = "Teams Private Channel Report"
+    WorksheetName = "Teams Private Channels"
+    AutoFilter    = $true 
+    AutoSize      = $true
+}
+
+Write-Host "Creating Excel File $reportFileName"
+$teamPrivateChannels | Select-Object Title, Url, StorageUsage, Owner, SiteDefinedSharingCapability `
+| Export-Excel @ExcelReportSettings
+
+# Save to SharePoint
+m365 spo file add --webUrl "https://contoso.sharepoint.com" --folder 'Shared Documents' --path $reportFileName
+
+Write-Host "Uploaded Excel File to SharePoint"
+
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+***
+
 ## Source Credit
 
 Sample first appeared on [Azure Automation to the Rescue – Session at Scottish Summit 2021 | CaPa Creative Ltd](https://capacreative.co.uk/2021/02/27/azure-automation-to-the-rescue-session-at-scottish-summit-2021/)
@@ -72,6 +118,7 @@ Sample first appeared on [Azure Automation to the Rescue – Session at Scottish
 | Author(s) |
 |-----------|
 | Paul Bullock |
+| [Adam Wójcik](https://github.com/Adam-it)|
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://telemetry.sharepointpnp.com/script-samples/scripts/report-private-teams-excel" aria-hidden="true" />

--- a/scripts/report-private-teams-excel/assets/sample.json
+++ b/scripts/report-private-teams-excel/assets/sample.json
@@ -17,6 +17,10 @@
         {
           "key": "PnP-PowerShell",
           "value": "1.5.0"
+        },
+        {
+          "key": "cli-for-microsoft365",
+          "value": "6.14.22"
         }
       ],
       "categories": [
@@ -31,6 +35,11 @@
         }
       ],
       "authors": [
+        {
+          "gitHubAccount": "Adam-it",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+          "name": "Adam Wójcik"
+        },
         {
           "gitHubAccount": "pkbullock",
           "company": "CaPa Creative Ltd",

--- a/scripts/report-private-teams-excel/assets/sample.json
+++ b/scripts/report-private-teams-excel/assets/sample.json
@@ -8,7 +8,7 @@
       "longDescription": [
       ],
       "creationDateTime": "2021-02-27",
-      "updateDateTime": "2021-02-27",
+      "updateDateTime": "2021-11-21",
       "products": [
         "SharePoint",
         "Teams"


### PR DESCRIPTION
### 🎯 PR aim
The aim of this PR is to add CLI for Microsoft 365 equivalent -
https://pnp.github.io/script-samples/report-private-teams-excel/README.html?tabs=pnpps

### ✔ What was done
- [X] updated readme with script
- [X] updated sample.json

### 🔗 Related
#120

### 📸 Result 
running the script
![image](https://user-images.githubusercontent.com/58668583/142774126-0ec81949-ac0e-4c32-a1cb-fa56cf4c5ef7.png)

excel result
![image](https://user-images.githubusercontent.com/58668583/142774136-8b55851f-e454-470c-ac6f-22eb21b9d090.png)

file added to SP
![image](https://user-images.githubusercontent.com/58668583/142774143-e5bd8711-3519-4815-b352-a7656dadbb40.png)


