### PR TITLE
Add CLI for Microsoft 365 to Remove delete option on a document library

### DIFF
--- a/scripts/remove-delete-option-library/README.md
+++ b/scripts/remove-delete-option-library/README.md
@@ -26,7 +26,6 @@ Write-Host "Done! :-)" -ForegroundColor Green
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
-***
 
 # [CLI for Microsoft 365](#tab/cli-m365-ps)
 ```powershell

--- a/scripts/remove-delete-option-library/README.md
+++ b/scripts/remove-delete-option-library/README.md
@@ -28,6 +28,26 @@ Write-Host "Done! :-)" -ForegroundColor Green
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
 
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+```powershell
+
+$m365Status = m365 status
+if ($m365Status -eq "Logged Out") {
+    m365 login
+}
+
+$site = "<site>"
+$list = "<list or library>"
+
+$json = m365 spo list get --title $list --webUrl $site
+$json = $json | ConvertFrom-Json
+m365 spo list set --webUrl $site --id $json.Id --allowDeletion false
+Write-Host "Done! :-)" -ForegroundColor Green
+
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+***
+
 ## Source Credit
 
 Sample first appeared on [Prevent document library deletion | CaPa Creative Ltd](https://capacreative.co.uk/2018/09/17/prevent-document-library-deletion/)
@@ -37,6 +57,7 @@ Sample first appeared on [Prevent document library deletion | CaPa Creative Ltd]
 | Author(s) |
 |-----------|
 | Paul Bullock |
+| [Adam Wójcik](https://github.com/Adam-it)|
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/remove-delete-option-library/assets/sample.json
+++ b/scripts/remove-delete-option-library/assets/sample.json
@@ -7,7 +7,7 @@
       "url": "remove-delete-option-library/README.html",
       "longDescription": [],
       "creationDateTime": "2018-09-17",
-      "updateDateTime": "2018-09-17",
+      "updateDateTime": "2021-12-12",
       "products": [
         "SharePoint"
       ],
@@ -15,6 +15,10 @@
         {
           "key": "PnP-PowerShell",
           "value": "1.5.0"
+        },
+        {
+          "key": "cli-for-microsoft365",
+          "value": "6.14.22"
         }
       ],
       "categories": [
@@ -29,6 +33,11 @@
         }
       ],
       "authors": [
+        {
+          "gitHubAccount": "Adam-it",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+          "name": "Adam Wójcik"
+        },
         {
           "gitHubAccount": "pkbullock",
           "company": "CaPa Creative Ltd",


### PR DESCRIPTION
### 🎯 PR aim
The aim of this PR is to add CLI for Microsoft 365 equivalent -
https://pnp.github.io/script-samples/remove-delete-option-library/README.html?tabs=pnpps

### ✔ What was done
- [X] updated readme with script
- [X] updated sample.json

### 🔗 Related
#121

### 📸 Result 
result of the script
![image](https://user-images.githubusercontent.com/58668583/145728731-845e7976-67d3-4cf0-8b9c-8de182774ded.png)


