### PR TITLE
Add CLI for Microsoft 365 to Generate Markdown Report of LCIDs

### DIFF
--- a/scripts/generate-markdown-lcids/README.md
+++ b/scripts/generate-markdown-lcids/README.md
@@ -35,6 +35,34 @@ Write-Host "Script Complete! :)" -ForegroundColor Green
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+```powershell
+
+$m365Status = m365 status
+if ($m365Status -eq "Logged Out") {
+    m365 login
+}
+
+$languages = m365 spo web installedlanguage list --webUrl 'https://contoso.sharepoint.com'
+$languages = $languages | ConvertFrom-Json
+
+# Markdown format
+$markdown = ""
+$markdown += "| Name | Language Tag | LCID |`n"
+$markdown += "|------|--------------|------|`n"
+
+$languages | foreach-object{ $markdown += "| $($_.DisplayName) | $($_.LanguageTag) | $($_.LCID) |`n"} 
+
+Write-Host $markdown
+
+# Copy to clipboard
+$markdown | clip
+
+Write-Host "Script Complete! :)" -ForegroundColor Green
+
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 ***
 
 ## Contributors
@@ -42,6 +70,7 @@ Write-Host "Script Complete! :)" -ForegroundColor Green
 | Author(s) |
 |-----------|
 | Paul Bullock |
+| [Adam Wójcik](https://github.com/Adam-it)|
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 

--- a/scripts/generate-markdown-lcids/assets/sample.json
+++ b/scripts/generate-markdown-lcids/assets/sample.json
@@ -9,7 +9,7 @@
         "Simple report listing out the language IDs (LCIDs) of a SharePoint site and generated a markdown formatted table"
       ],
       "creationDateTime": "2021-05-11",
-      "updateDateTime": "2021-05-11",
+      "updateDateTime": "2021-12-18",
       "products": [
         "SharePoint"
       ],
@@ -17,6 +17,10 @@
         {
           "key": "PnP-PowerShell",
           "value": "1.5.0"
+        },
+        {
+          "key": "cli-for-microsoft365",
+          "value": "6.14.22"
         }
       ],
       "categories": [
@@ -31,6 +35,11 @@
         }
       ],
       "authors": [
+        {
+          "gitHubAccount": "Adam-it",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+          "name": "Adam Wójcik"
+        },
         {
           "gitHubAccount": "pkbullock",
           "company": "CaPa Creative Ltd",


### PR DESCRIPTION
### 🎯 PR aim
The aim of this PR is to add CLI for Microsoft 365 equivalent -
https://pnp.github.io/script-samples/generate-markdown-lcids/README.html?tabs=pnpps

### ✔ What was done
- [X] updated readme with script
- [X] updated sample.json

### 🔗 Related
#118

### 📸 Result 
result of the script
![image](https://user-images.githubusercontent.com/58668583/146654868-1716e855-9757-450b-9ac0-e6f288752670.png)


