### PR TITLE
Fixes for small screen display overlaps

### DIFF
--- a/docfx/templates/material/styles/main.css
+++ b/docfx/templates/material/styles/main.css
@@ -791,6 +791,12 @@ p.sample-title {
   display: -webkit-box !important;
 }
 
+@media screen and (max-width: 385px) {
+  p.sample-title {
+    -webkit-line-clamp: 2;
+  }
+}
+
 
 .producttype-item:first-child{
   z-index: 50;

--- a/docfx/templates/material/styles/main.css
+++ b/docfx/templates/material/styles/main.css
@@ -784,6 +784,11 @@ pre{
 
 p.sample-title {
   margin-top: 0.2em;
+  margin-top: 0.2em;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  display: -webkit-box !important;
 }
 
 


### PR DESCRIPTION
Fixed visual bug on small cards where the description and title is overflowing over the author metadata

Reference #219 Issue