### PR TITLE
Updated flow run day summary example to add PnP PS

### DIFF
--- a/scripts/flow-runs-day-summary/README.md
+++ b/scripts/flow-runs-day-summary/README.md
@@ -6,15 +6,17 @@ plugin: add-to-gallery
 
 ## Summary
 
-Powershell script that could run once a day and sends summary (for example adaptive card in teams) with list of all flows runs with total runs count for current day, number of times the flow succeeded and number of times the flow failed
+Powershell scripts using CLI for M365 and PnP PowerShell that could run once a day and sends a summary (for example adaptive card in teams) with list of all flows runs with total runs count for current day, number of times the flow succeeded and number of times the flow failed
 
-result in console
+result in console (CLI)
 
 ![run in console](assets/example2.png)
 
 result as adaptive card in teams
 
 ![adaptive card in teams](assets/example.png)
+
+Both CLI and PnP PowerShell solutions require a Microsoft Teams channel to be configured with a webhook to accept incoming messages. Follow instructions on Adam the Automators blog here ([Setting up a Webhook Connector in Microsoft Teams](https://adamtheautomator.com/teams-webhooks/#Setting_up_a_Webhook_Connector_in_Microsoft_Teams))
  
 # [CLI for Microsoft 365 with PowerShell](#tab/cli-m365-ps)
 ```powershell
@@ -70,10 +72,103 @@ m365 adaptivecard send --url $webhook --card $adaptiveCard --cardData $cardData
 ```
 [!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 
+# [PnP PowerShell](#tab/pnpps)
+
+```powershell
+
+
+Connect-PnPOnline -Url https://contoso-admin.sharepoint.com -Interactive
+
+$environment = 'Default-d2af3166-e76b-4d03-9942-fbc79d6b69f9' #Change to your Power Automate environment
+
+#Setup an incoming webhook to a Microsoft Team channel and replace $webhook variable
+#https://adamtheautomator.com/teams-webhooks/#Setting_up_a_Webhook_Connector_in_Microsoft_Teams
+$webhook = 'https://leonarmstondev.webhook.office.com/webhookb2/908a4576-7946-405d-b373-0ff49b7244e1@d2af3166-e76b-4d03-9942-fbc79d6b69f9/IncomingWebhook/27f804496eb749158838186717fef3c0/08a5b26d-e908-49af-b8c6-e84d06beda87'
+
+
+$currentDayDate = Get-Date
+$previousDayDate = (Get-Date).AddDays(-1)
+$adaptiveCardDescription = ""
+
+$flows = Get-PnPFlow -Environment $environment
+foreach ($flow in $flows) 
+{
+    $flowRuns = Get-PnPFlowRun -Environment $environment -Flow $flow.Name
+
+    $displayName = $flow.Properties.DisplayName
+    $id = $flow.name
+
+    $todayRuns = $flowRuns.Where({[DateTime]$_.Properties.EndTime -le $currentDayDate -and [DateTime]$_.Properties.EndTime -gt $previousDayDate})
+    
+    $todayRunsCount = 0
+    $todaySuccessRunsCount = 0
+    $todayFailedRunsCount = 0
+    if($todayRuns.Count -gt 0)
+    {
+        $todaySuccessRuns = $todayRuns.Where({$_.Properties.Status -eq 'Succeeded'})
+        $todaySuccessRunsCount = $todaySuccessRuns.Count
+
+        $todayFailedRuns = $todayRuns.Where({$_.Properties.Status -eq 'Failed'})
+        $todayFailedRunsCount = $todayFailedRuns.Count
+
+        $todayRunsCount = $todayRuns.Count
+    }
+
+    Write-Host "$displayName -> Runs: $todayRunsCount , Succeeded: $todaySuccessRunsCount , Failed: $todayFailedRunsCount"
+    $adaptiveCardDescription = $adaptiveCardDescription + "\r- [$displayName](https://us.flow.microsoft.com/manage/environments/$environment/flows/$id/details) -> Runs: $todayRunsCount , Succeeded: $todaySuccessRunsCount , Failed: $todayFailedRunsCount"
+}
+$today = Get-Date -Format "dd/MM/yyyy"
+
+$JSON = [Ordered]@{
+  "type"       = "message"
+  "attachments" = @(
+    @{
+      "contentType" = 'application/vnd.microsoft.card.adaptive'
+      "content"     = [Ordered]@{
+        '$schema' = "<http://adaptivecards.io/schemas/adaptive-card.json>"
+        "type"    = "AdaptiveCard"
+        "version" = "1.3"
+        "body"    = @(
+          [Ordered]@{
+            "type"  = "Container"
+            "items" = @(
+              @{
+			    "type"= "TextBlock"
+			    "size"= "Medium"
+			    "weight"= "Bolder"
+			    "text"= "Today's Power Automate Flow Summary - $today"
+              }
+              @{
+			    "type"= "TextBlock"
+			    "text"= "${adaptiveCardDescription}"
+			    "wrap"= $true
+              }
+            )
+          }
+        )
+      }
+    }
+  )
+} | ConvertTo-JSON -Depth 20
+
+$Params = @{
+  "URI"         = $webhook
+  "Method"      = 'POST'
+  "Body"        = [string]$json.replace("\\","\");
+  "ContentType" = 'application/json'
+}
+
+Invoke-RestMethod @Params
+```
+[!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+***
+
 ## Contributors
 
 | Author(s) |
 |-----------|
+| [Leon Armston](https://github.com/LeonArmston)|
 | [Adam Wójcik](https://github.com/Adam-it)|
 
 

--- a/scripts/flow-runs-day-summary/assets/sample.json
+++ b/scripts/flow-runs-day-summary/assets/sample.json
@@ -26,6 +26,10 @@
     ],
     "metadata": [
       {
+        "key": "PNP-POWERSHELL",
+        "value": "1.10.0"
+      },
+      {
         "key": "CLI-FOR-MICROSOFT365",
         "value": "3.7.0"
       }
@@ -40,6 +44,12 @@
       }
     ],
     "authors": [
+       {
+        "gitHubAccount": "LeonArmston",
+        "company": "Intelogy",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/12968962?v=4",
+        "name": "Leon Armston"
+      },
       {
         "gitHubAccount": "Adam-it",
         "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
@@ -51,6 +61,11 @@
         "name": "Want to learn more about CLI for Microsoft 365 and the commands",
         "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
         "url": "https://aka.ms/cli-m365"
+      },
+       {
+        "name": "Want to learn more about PnP PowerShell and the cmdlets",
+        "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
+        "url": "https://aka.ms/pnp/powershell"
       }
     ]
   }

--- a/scripts/flow-runs-day-summary/assets/sample.json
+++ b/scripts/flow-runs-day-summary/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "Flows runs day summary",
     "url": "https://pnp.github.io/script-samples/flow-runs-day-summary/README.html",
     "creationDateTime": "2021-10-27",
-    "updateDateTime": "2021-10-27",
+    "updateDateTime": "2022-05-11",
     "shortDescription": "This script creates a report of all flow runs from current day and sends the report as an adaptive card to the provided url",
     "longDescription": null,
     "products": [


### PR DESCRIPTION
With the creation of the Get-PnPFlowRuns PnP PowerShell cmdlet recently I have now updated the flow run day summary - post to adaptive card example to add PnP PS.
Have also updated the intro wording to tell the user how to create an incoming webhook for the Microsoft Team.