### PR TITLE
M365 CLI - Bulk library generation

### DIFF
--- a/scripts/spo-create-bulk-libraries/README.md
+++ b/scripts/spo-create-bulk-libraries/README.md
@@ -26,7 +26,7 @@ With this sample, you can create a whole bunch of libraries at once. These are f
 ```powershell
 
 # Usage example: 
-#     .\Create-Bulk-Libraries.ps1 -TargetSitePartUrl mytargetsite -PartTenant contoso AmountLibraries 3
+#     .\Create-Bulk-Libraries.ps1 -TargetSitePartUrl mytargetsite -PartTenant contoso -AmountLibraries 3
 
 [CmdletBinding()]
 param (
@@ -87,7 +87,7 @@ process {
 
 ```powershell
 # Usage example: 
-#     .\Create-Bulk-Libraries.ps1 -TargetWebUrl https://contoso.sharepoint.com/sites/Intranet AmountLibraries 3
+#     .\Create-Bulk-Libraries.ps1 -TargetWebUrl https://contoso.sharepoint.com/sites/Intranet -AmountLibraries 3
 
 [CmdletBinding()]
 param (

--- a/scripts/spo-create-bulk-libraries/README.md
+++ b/scripts/spo-create-bulk-libraries/README.md
@@ -14,8 +14,7 @@ With this sample, you can create a whole bunch of libraries at once. These are f
 
 | Parameter         | Mandatory | Description                               | Default value        |
 |-------------------|-----------|-------------------------------------------|----------------------|
-| TargetSitePartUrl |    Yes    | Target site                               |                      |
-| Part tenant       |    Yes    | Organisation url fragment                 |                      |
+| TargetWebUrl      |    Yes    | Target SharePoint site                    |                      |
 | AmountLibraries   |     No    | Amount of libraries to create             |           5          |
 | LibraryName       |     No    | Name for your libraries                   |   Parker's Library   |
 | LibraryTemplate   |     No    | Library template to use for bulk creation |    DocumentLibrary   |
@@ -31,8 +30,8 @@ With this sample, you can create a whole bunch of libraries at once. These are f
 
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory = $true, HelpMessage = "Target site e.g. Intranet")]
-    [string]$TargetSitePartUrl,
+    [Parameter(Mandatory = $true, HelpMessage = "Target site e.g. https://contoso.sharepoint.com/sites/Intranet")]
+    [string]$TargetWebUrl,
 
     [Parameter(Mandatory = $true, HelpMessage = "Organisation url fragment e.g. contoso ")]
     [string]$PartTenant,
@@ -53,12 +52,9 @@ param (
     [string]$LibraryView = "Parker's Perspective"
 )
 begin {
-    $baseUrl = "https://$($PartTenant).sharepoint.com"
-    $targetSiteUrl = "$($baseUrl)/sites/$($TargetSitePartUrl)"
-
-    Write-Host "`nConnecting to " $targetSiteUrl
+    Write-Host "`nConnecting to " $TargetWebUrl
         
-    Connect-PnPOnline -Url $targetSiteUrl -ReturnConnection -Interactive | Out-Null
+    Connect-PnPOnline -Url $TargetWebUrl -ReturnConnection -Interactive | Out-Null
 }
 process {
     Write-Host "`nCreating new libraries..." -ForegroundColor Cyan
@@ -86,6 +82,66 @@ process {
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
+
+# [CLI for Microsoft 365 with PowerShell](#tab/cli-m365-ps)
+
+```powershell
+# Usage example: 
+#     .\Create-Bulk-Libraries.ps1 -TargetWebUrl https://contoso.sharepoint.com/sites/Intranet AmountLibraries 3
+
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $true, HelpMessage = "Target site e.g. https://contoso.sharepoint.com/sites/Intranet")]
+  [string]$TargetWebUrl,
+
+  [Parameter(Mandatory = $false, HelpMessage = "Amount of libraries to create e.g. 5 ")]
+  [float]$AmountLibraries = 5,
+
+  [Parameter(Mandatory = $false, HelpMessage = "Name for your libraries e.g. Parker's Library ")]
+  [string]$LibraryName = "Parker's Library",
+
+  [Parameter(Mandatory = $false, HelpMessage = "Library template to use for bulk creation e.g. DocumentLibrary ")]
+  [string]$LibraryTemplate = "DocumentLibrary",
+
+  [Parameter(Mandatory = $false, HelpMessage = "Fields to add to your library e.g. Description,Status ")]
+  [string[]]$LibraryFields = @("Description", "Status"),
+
+  [Parameter(Mandatory = $false, HelpMessage = "View name to add to your library e.g. Parker's Perspective ")]
+  [string]$LibraryView = "Parker's Perspective"
+)
+begin {
+  $m365Status = m365 status
+  if ($m365Status -eq "Logged Out") {
+    m365 login
+  }
+}
+process {
+  Write-Host "`nCreating new libraries..." -ForegroundColor Cyan
+  Write-Progress -Activity "Library creation" -Status "Creating libraries" -PercentComplete 0
+  
+  for ($counter = 1; $counter -le $AmountLibraries; $counter++ )
+  {
+    $newList = m365 spo list add --webUrl $TargetWebUrl --title "$($LibraryName) $($counter)" --baseTemplate $LibraryTemplate | ConvertFrom-Json
+
+    if ($null -ne $LibraryFields) {
+      foreach ($fieldName in $LibraryFields) {
+        $internalFieldName = $fieldName.replace(' ', '')
+        m365 spo field add --webUrl $TargetWebUrl --listTitle $newList.Title.Replace("'", "''") --xml "<Field Type='Text' DisplayName='$($fieldName)' StaticName='$($internalFieldName)' Name='$($internalFieldName)' />" | Out-Null
+      }
+    }
+
+    if ($null -ne $LibraryView) {
+      m365 spo list view add --webUrl $TargetWebUrl --listId $newList.Id --title $LibraryView --fields $($LibraryFields -Join ",") | Out-Null
+    }
+
+    Write-Progress -Activity "Library creation" -Status "$counter libraries created" -PercentComplete (($counter / $AmountLibraries) * 100)
+  }
+
+  Write-Host "`nScript Complete! :)" -ForegroundColor Green
+}
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 
 ## Contributors
 

--- a/scripts/spo-create-bulk-libraries/README.md
+++ b/scripts/spo-create-bulk-libraries/README.md
@@ -81,7 +81,6 @@ process {
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
-***
 
 # [CLI for Microsoft 365 with PowerShell](#tab/cli-m365-ps)
 
@@ -148,6 +147,7 @@ process {
 | Author(s) |
 |-----------|
 | Jasey Waegebaert |
+| Milan Holemans |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/spo-create-bulk-libraries/assets/sample.json
+++ b/scripts/spo-create-bulk-libraries/assets/sample.json
@@ -9,7 +9,7 @@
       "With this sample, you can create a whole bunch of libraries at once. These are fairly simple libraries with an extra view and a few extra columns."
     ],
     "creationDateTime": "2022-03-29",
-    "updateDateTime": "2022-03-29",
+    "updateDateTime": "2022-05-27",
     "products": [
       "SharePoint"
     ],
@@ -17,6 +17,10 @@
       {
         "key": "PNP-POWERSHELL",
         "value": "1.9.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "4.3.0"
       }
     ],
     "categories": [
@@ -25,7 +29,16 @@
     ],
     "tags": [
       "bash",
-      "classic"
+      "classic",
+      "m365 login",
+      "m365 status",
+      "m365 spo field add",
+      "m365 spo list add",
+      "m365 spo list view add",
+      "Add-PnPField",
+      "Add-PnPView",
+      "Connect-PnPOnline",
+      "New-PnPList"
     ],
     "thumbnails": [
       {
@@ -36,6 +49,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "milanholemans",
+        "company": "",
+        "pictureUrl": "https://github.com/milanholemans.png",
+        "name": "Milan Holemans"
+      },
       {
         "gitHubAccount": "Jwaegebaert",
         "company": "GMI Group",


### PR DESCRIPTION
Closes #274 

## Remarks
* `m365 spo list view add` command is in preview at this moment. You should use v5.3.0 preview version of M365 CLI
* Replaced the `TargetSitePartUrl` and the `PartTenant` parameters by `TargetWebUrl`. Right now we assume that the target SharePoint URL is `"https://$($PartTenant).sharepoint.com/sites/$($TargetSitePartUrl)"`. This is not always the case, tenants are able to use other prefixes than `/sites`.