### PR TITLE
Added CLI for M365 version for script "Reset files permissions unique to Inherited"

### DIFF
--- a/scripts/reset-files-permission-unique-to-inherited/README.md
+++ b/scripts/reset-files-permission-unique-to-inherited/README.md
@@ -47,6 +47,43 @@ foreach($folder in $folders){
 Disconnect-PnPOnline
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+```powershell
+#Log in to Microsoft 365
+Write-Host "Connecting to Tenant" -f Yellow
+
+$m365Status = m365 status
+if ($m365Status -eq "Logged out") {
+    m365 login
+}
+
+$siteURL = Read-Host "Please enter Site URL"
+$listName = Read-Host "Please enter list name"
+
+# Get the list
+$list = m365 spo list list --webUrl $siteURL --query "[?RootFolder.Name == '$listName']" --output json | ConvertFrom-Json
+
+# Get all files in the list
+$files = m365 spo file list --webUrl $siteURL --folder $listName --recursive --output json | ConvertFrom-Json
+foreach ($file in $files) {
+    # Avoid error: Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated keys 'Id' and 'ID'
+    $fileProperties = m365 spo file get --webUrl $siteURL --id $file.UniqueId --asListItem --output json | ForEach-Object { $_.replace("Id", "_Id") } | ConvertFrom-Json
+    
+    if ($fileProperties.ID) {
+        Write-Host "Processing file $($file.ServerRelativeUrl)"
+
+        # Get the list item
+        $listItem = m365 spo listitem get --webUrl $siteURL --listId $list.Id --id $fileProperties.ID --properties "HasUniqueRoleAssignments"
+        if ($listItem.HasUniqueRoleAssignments) {
+            Write-Host "Restoring the role inheritance of list item: $($file.ServerRelativeUrl)"
+            m365 spo listitem roleinheritance reset --webUrl $siteURL --listItemId $fileProperties.ID --listId $list.Id
+        }
+    }
+}
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 ***
 
 ## Contributors
@@ -54,6 +91,7 @@ Disconnect-PnPOnline
 | Author(s) |
 |-----------|
 | [Dipen Shah](https://github.com/dips365) |
+| [Nanddeep Nachan](https://github.com/nanddeepn) |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/reset-files-permission-unique-to-inherited/README.md
+++ b/scripts/reset-files-permission-unique-to-inherited/README.md
@@ -75,7 +75,7 @@ foreach ($file in $files) {
         Write-Host "Processing file $($file.ServerRelativeUrl)"
 
         # Get the list item
-        $listItem = m365 spo listitem get --webUrl $siteURL --listId $list.Id --id $fileProperties.ID --properties "HasUniqueRoleAssignments"
+        $listItem = m365 spo listitem get --webUrl $siteURL --listId $list.Id --id $fileProperties.ID --properties "HasUniqueRoleAssignments" | ConvertFrom-Json
         if ($listItem.HasUniqueRoleAssignments) {
             Write-Host "Restoring the role inheritance of list item: $($file.ServerRelativeUrl)"
             m365 spo listitem roleinheritance reset --webUrl $siteURL --listItemId $fileProperties.ID --listId $list.Id

--- a/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
+++ b/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
@@ -42,6 +42,7 @@
       "m365 spo list list",
       "m365 spo file list",
       "m365 spo file get",
+      "m365 spo listitem get",
       "m365 spo listitem roleinheritance reset"
     ],
     "thumbnails": [

--- a/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
+++ b/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
@@ -55,16 +55,16 @@
     ],
     "authors": [
       {
+        "gitHubAccount": "nanddeepn",
+        "pictureUrl": "https://github.com/nanddeepn.png",
+        "name": "Nanddeep Nachan"
+      },
+      {
         "gitHubAccount": "dips365",
         "company": "Rapid Circle",
         "pictureUrl": "https://avatars.githubusercontent.com/u/40450958?v=4",
         "name": "Dipen Shah"
-      },
-      {
-        "gitHubAccount": "nanddeepn",
-        "pictureUrl": "https://github.com/nanddeepn.png",
-        "name": "Nanddeep Nachan"
-      }
+      }      
     ],
     "references": [
       {

--- a/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
+++ b/scripts/reset-files-permission-unique-to-inherited/assets/sample.json
@@ -9,7 +9,7 @@
       ""
     ],
     "creationDateTime": "2021-08-11",
-    "updateDateTime": "2021-08-11",
+    "updateDateTime": "2022-06-01",
     "products": [
       "SharePoint"
     ],
@@ -17,6 +17,10 @@
       {
         "key": "PNP-POWERSHELL",
         "value": "1.5.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "3.7.0"
       }
     ],
     "categories": [
@@ -32,7 +36,13 @@
       "Get-PnPFolder",
       "Get-PnPList",
       "Get-PnPListItem",
-      "Get-PnPProperty"
+      "Get-PnPProperty",
+      "m365 login",
+      "m365 status",
+      "m365 spo list list",
+      "m365 spo file list",
+      "m365 spo file get",
+      "m365 spo listitem roleinheritance reset"
     ],
     "thumbnails": [
       {
@@ -48,6 +58,11 @@
         "company": "Rapid Circle",
         "pictureUrl": "https://avatars.githubusercontent.com/u/40450958?v=4",
         "name": "Dipen Shah"
+      },
+      {
+        "gitHubAccount": "nanddeepn",
+        "pictureUrl": "https://github.com/nanddeepn.png",
+        "name": "Nanddeep Nachan"
       }
     ],
     "references": [
@@ -55,6 +70,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
Added CLI for M365 version for script [Reset files permissions unique to Inherited](https://pnp.github.io/script-samples/reset-files-permission-unique-to-inherited/README.html?tabs=pnpps)
Closes #281

@Adam-it 
I did it bit differently by using [m365 spo file list](https://pnp.github.io/cli-microsoft365/cmd/spo/file/file-list/), so that we can recursively get all the files at one go.

Please have your review.