### PR TITLE
Markdown code block fix

### DIFF
--- a/scripts/planner-copy-planner-plan/README.md
+++ b/scripts/planner-copy-planner-plan/README.md
@@ -33,7 +33,6 @@ Following data will be copied:
 # Usage example:
 # .\Copy-Planner-plan.ps1 -SourcePlanId xqQg5FS2LkCp935s-FIFm2QAFkHM -DestinationGroupId 00000000-0000-0000-0000-000000000000
 
-```powershell
 [CmdletBinding()]
 param (
   [Parameter(Mandatory = $true, HelpMessage = "Source Planner plan to copy e.g. xqQg5FS2LkCp935s-FIFm2QAFkHM.")]


### PR DESCRIPTION
Noticed that the script `Copy Planner plan` has a markdown code block tag displayed.

![image](https://user-images.githubusercontent.com/11723921/172490482-c96f74a0-1729-4436-a7ee-5f94f1c58ed7.png)
