### PR TITLE
`Copy Planner Plan` updated to work with CLI v5.4.0

### DIFF
--- a/scripts/planner-copy-planner-plan/README.md
+++ b/scripts/planner-copy-planner-plan/README.md
@@ -15,6 +15,7 @@ Following data will be copied:
   * Title
   * Notes
   * Progress
+  * Priority
   * Start date
   * Due date
 
@@ -50,19 +51,6 @@ begin {
   }
 }
 process {
-  # Get valid ISO date for CLI to work with
-  function Get-IsoDate {
-    param (
-      [Parameter(Mandatory = $true)]
-      [datetime]$Date
-    )
-    if ($Date -eq $null) {
-      return $Date
-    }
-  
-    return $Date.ToString("o").Split('.')[0] + "Z"
-  }
-
   Write-Host "Copying plan..." -ForegroundColor Yellow
   $ProgressActivity = "Copying Planner plan"
   Write-Progress -Activity $ProgressActivity -Status "Reading source plan data" -PercentComplete 0
@@ -91,18 +79,18 @@ process {
   Write-Progress -Activity $ProgressActivity -Status "Creating tasks" -PercentComplete 75
 
   foreach ($task in $tasks) {
-    $command = "m365 planner task add --planId $($clonedPlan.id) --bucketId $($bucketMapping[$task.bucketId]) --title '$($task.title.Replace("'", "''"))' --percentComplete $($task.percentComplete)"
+    $command = "m365 planner task add --planId $($clonedPlan.id) --bucketId $($bucketMapping[$task.bucketId]) --title '$($task.title.Replace("'", "''"))' --percentComplete $($task.percentComplete)  --priority $($task.priority)"
     
     # Append optional options when needed
     if ($task.hasDescription) {
-      $details = m365 planner task details get --taskId $task.id | ConvertFrom-Json
+      $details = m365 planner task get --id $task.id | ConvertFrom-Json
       $command += " --description '$($details.description.Replace("'", "''"))'"
     }
     if ($null -ne $task.startDateTime) {
-      $command += " --startDateTime $(Get-IsoDate $task.startDateTime)"
+      $command += " --startDateTime $($task.startDateTime)"
     }
     if ($null -ne $task.dueDateTime) {
-      $command += " --dueDateTime $(Get-IsoDate $task.dueDateTime)"
+      $command += " --dueDateTime $($task.dueDateTime)"
     }
 
     Invoke-Expression $command | Out-Null

--- a/scripts/planner-copy-planner-plan/assets/sample.json
+++ b/scripts/planner-copy-planner-plan/assets/sample.json
@@ -9,14 +9,14 @@
       "With this sample, you can copy an existing Planner plan to a specific group. This script will create a new plan with the same name and copy all buckets and tasks."
     ],
     "creationDateTime": "2022-06-05",
-    "updateDateTime": "2022-06-05",
+    "updateDateTime": "2022-06-22",
     "products": [
       "Planner"
     ],
     "metadata": [
       {
         "key": "CLI-FOR-MICROSOFT365",
-        "value": "5.3.0"
+        "value": "5.4.0"
       }
     ],
     "categories": [
@@ -31,7 +31,7 @@
       "m365 planner plan get",
       "m365 planner bucket list",
       "m365 planner task list",
-      "m365 planner task details get",
+      "m365 planner task get",
       "m365 planner plan add",
       "m365 planner bucket add",
       "m365 planner task add"


### PR DESCRIPTION
Because there is a new CLI version, following adjustments were made:
* Copy priority of task as well
* Removed deprecated command `m365 planner task details get`
* Removed conversion method to convert date to valid ISO string (this has been fixed)