### PR TITLE
CLI for M365 version of script - Download contents of Document library as PDF

### DIFF
--- a/scripts/graph-download-office-documents-as-pdf/assets/sample.json
+++ b/scripts/graph-download-office-documents-as-pdf/assets/sample.json
@@ -9,7 +9,7 @@
       "Script to download files in a doclib to a local drive and convert Office Documents to PDF"
     ],
     "creationDateTime": "2021-08-13",
-    "updateDateTime": "2021-08-13",
+    "updateDateTime": "2023-01-15",
     "products": [
       "SharePoint",
       "Graph"
@@ -18,6 +18,10 @@
       {
         "key": "POWERSHELL",
         "value": "7.2.0"
+      },
+      {
+        "key": "cli-for-microsoft365",
+        "value": "6.1.0"
       }
     ],
     "categories": [
@@ -42,6 +46,11 @@
         "company": "",
         "pictureUrl": "https://avatars.githubusercontent.com/u/2412956?v=4",
         "name": "Russell Gove"
+      },
+      {
+        "gitHubAccount": "Adam-it",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+        "name": "Adam Wójcik"
       }
     ],
     "references": [
@@ -49,6 +58,11 @@
         "name": "Want to learn more about the Microsoft Graph",
         "description": "Check out the documentation site to get started and for the reference to the endpoints.",
         "url": "https://developer.microsoft.com/en-us/graph/graph-explorer"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
## 🎯 Aim

The aim of this issue would be to add a [CLI for M365](https://pnp.github.io/cli-microsoft365/) version of script [Download contents of Document library as PDF](https://pnp.github.io/script-samples/graph-download-office-documents-as-pdf/README.html?tabs=pnpps).

## 🔗 Related issue

Closes: #357

## 📷 Result

After running the script locally I have the same files as in the related document library converted to pdfs 
![image](https://user-images.githubusercontent.com/58668583/212572087-7ec8f8de-373c-47f7-a374-1ce287d272c9.png)
