### PR TITLE
CLI for M365 version of script -Reports to Excel where the specified Term is used

### DIFF
--- a/scripts/ReportTermUse/README.md
+++ b/scripts/ReportTermUse/README.md
@@ -222,9 +222,9 @@ $outputArray  | Export-Csv -Path $outputPath -Force -Encoding utf8BOM -Delimiter
 
 | Author(s) |
 |-----------|
-| [Kasper Bo Larsen](https://github.com/kasperbolarsen|
+| [Kasper Bo Larsen](https://github.com/kasperbolarsen)|
 | [Adam Wójcik](https://github.com/Adam-it)|
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
-<img src="https://pnptelemetry.azurewebsites.net/script-samples/scripts/report-private-teams-excel" aria-hidden="true" />
+<img src="https://pnptelemetry.azurewebsites.net/script-samples/scripts/report-term-use" aria-hidden="true" />
 

--- a/scripts/ReportTermUse/README.md
+++ b/scripts/ReportTermUse/README.md
@@ -128,6 +128,94 @@ $outputArray  | Export-Csv -Path $outputPath -Force -Encoding utf8BOM -Delimiter
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+```powershell
+
+
+#Set Variables
+$targetTermSetId = "cca0fb68-25e6-4b83-a998-9ad4e82c68f8"
+$targetTermId = "6816b2d7-ea71-4906-8f25-e45acc32ede2"
+$outputPath = "C:\temp\whereisthatTermidused.csv" 
+
+#Get Credentials to connect
+$m365Status = m365 status
+if ($m365Status -match "Logged Out") {
+   m365 login
+}
+
+function LookForTermInWeb ($webUrl, $title)
+{
+    $lists = m365 spo list list --webUrl $webUrl | ConvertFrom-Json
+    foreach($list in $lists)
+    {
+        if ($list.Hidden -eq 'False') { continue }
+        $taxfields = m365 spo field list --webUrl $webUrl --listTitle $list.Title  | ConvertFrom-Json
+        foreach($taxfield in $taxfields)
+        {
+            if($taxfield.TypeAsString -eq "TaxonomyFieldType" -and $taxfield.TermSetId -eq $targetTermSetId)
+            {
+                $listitems = m365 spo listitem list --listTitle $list.Title --webUrl $webUrl | ConvertFrom-Json
+                foreach($listitem in $listitems)
+                {
+                    $field = $listitem."$($taxfield.InternalName)"
+                    if($field)
+                    {
+                        $termguid = $field.TermGuid
+                        if($termguid -and $termguid -eq $targetTermId)
+                        {
+                            $element = "" | Select-Object SiteUrl, Title, ListTitle, fieldname, fieldvalue
+                            $element.SiteUrl = $webUrl
+                            $element.Title =  $title
+                            $element.ListTitle = $list.Title
+                            $element.fieldname = $taxfield.Title
+                            $element.fieldvalue = $field.Label
+                            $outputArray.Add($element) | Out-Null
+                        }
+                    }
+                    
+                }
+            }
+        }
+    }
+}
+
+$outputArray = [System.Collections.ArrayList]@()
+ 
+Try {
+    #Connect to PnP Online
+    $SitesCollections = m365 spo site list | ConvertFrom-Json
+
+    $index = 0
+    #Loop through each site collection
+    ForEach($Site in $SitesCollections) 
+    { 
+        Write-host -ForegroundColor Green "$($Site.Url ) , number $index of $($SitesCollections.Count)"
+        $index++
+        Try 
+        {
+            LookForTermInWeb -webUrl $Site.Url -title $Site.Title
+            $SubSites = m365 spo web list --url $Site.Url | ConvertFrom-Json
+            ForEach ($web in $SubSites)
+            {
+                Write-host "Web  : $($Web.Url)"
+                LookForTermInWeb -webUrl $Web.Url -title $Site.Title
+            }
+        }
+        Catch {
+            write-host -f Red "`tError:" $_.Exception.Message
+        }
+    }
+}
+Catch {
+    write-host -f Red "Error:" $_.Exception.Message
+}
+
+$outputArray  | Export-Csv -Path $outputPath -Force -Encoding utf8BOM -Delimiter "|"
+
+
+```
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 ***
 
 ## Contributors
@@ -135,6 +223,7 @@ $outputArray  | Export-Csv -Path $outputPath -Force -Encoding utf8BOM -Delimiter
 | Author(s) |
 |-----------|
 | [Kasper Bo Larsen](https://github.com/kasperbolarsen|
+| [Adam Wójcik](https://github.com/Adam-it)|
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://pnptelemetry.azurewebsites.net/script-samples/scripts/report-private-teams-excel" aria-hidden="true" />

--- a/scripts/ReportTermUse/assets/sample.json
+++ b/scripts/ReportTermUse/assets/sample.json
@@ -15,6 +15,10 @@
       {
         "key": "PNP-POWERSHELL",
         "value": "1.5.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "6.1.0"
       }
     ],
     "categories": [
@@ -33,6 +37,11 @@
         "gitHubAccount": "Kasper Larsen",
         "pictureUrl": "https://avatars.githubusercontent.com/u/20593570?s=400&u=f9a4d5137685d8c3fcc60394fc193f3e8156f678&v=4",
         "name": "Kasper Bo Larsen"
+      },
+      {
+        "gitHubAccount": "Adam-it",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
+        "name": "Adam Wójcik"
       }
     ],
     "references": [
@@ -40,6 +49,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }

--- a/scripts/ReportTermUse/assets/sample.json
+++ b/scripts/ReportTermUse/assets/sample.json
@@ -7,7 +7,7 @@
     "url": "https://pnp.github.io/script-samples/ReportTermUse/README.html",
     "longDescription": [],
     "creationDateTime": "2021-12-13",
-    "updateDateTime": "2021-12-13",
+    "updateDateTime": "2023-01-16",
     "products": [
       "SharePoint"
     ],
@@ -34,14 +34,14 @@
     ],
     "authors": [
       {
-        "gitHubAccount": "Kasper Larsen",
-        "pictureUrl": "https://avatars.githubusercontent.com/u/20593570?s=400&u=f9a4d5137685d8c3fcc60394fc193f3e8156f678&v=4",
-        "name": "Kasper Bo Larsen"
-      },
-      {
         "gitHubAccount": "Adam-it",
         "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4",
         "name": "Adam Wójcik"
+      },
+      {
+        "gitHubAccount": "Kasper Larsen",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/20593570?s=400&u=f9a4d5137685d8c3fcc60394fc193f3e8156f678&v=4",
+        "name": "Kasper Bo Larsen"
       }
     ],
     "references": [


### PR DESCRIPTION
## 🎯 Aim

The aim of this issue would be to add a [CLI for M365](https://pnp.github.io/cli-microsoft365/) version of script [Reports to Excel where the specified Term is used](https://pnp.github.io/script-samples/ReportTermUse/README.html?tabs=pnpps).

## 🔗 Related issue

Closes: #308

## 📷 Result

After running the script locally I have the csv report from all sites, lists, etc that use this termset field
![image](https://user-images.githubusercontent.com/58668583/212777737-0c97fe63-126e-4903-806c-841e8febc483.png)

