### PR TITLE
Sample Update - List all Microsoft Teams team's Owners and Members

### DIFF
--- a/scripts/teams-list-teams-owners-and-members/README.md
+++ b/scripts/teams-list-teams-owners-and-members/README.md
@@ -9,10 +9,12 @@ plugin: add-to-gallery
 This script allows you to list all Teams team's owners and members and export them into a CSV file. This script is inspired by [Robin Clarke](https://dailysysadmin.com/KB/Article/3607/microsoft-teams-powershell-commands-to-list-all-members-and-owners/)
  
 # [PnP PowerShell](#tab/pnpps)
+
 ```powershell
+
 $AdminCenterURL="https://contoso-admin.sharepoint.com/"
 
-#Connect to SharePoint Online admin center
+# Connect to SharePoint Online admin center
 Connect-PnPOnline -Url $AdminCenterURL -Interactive
 
 $dateTime = (Get-Date).toString("dd-MM-yyyy")
@@ -21,31 +23,84 @@ $directorypath = Split-Path $invocation.MyCommand.Path
 $fileName = "m365GroupUsersReport-" + $dateTime + ".csv"
 $OutPutView = $directorypath + "\Logs\"+ $fileName
 
-#Array to Hold Result - PSObjects
-
+# Array to Hold Result - PSObjects
 $m365GroupCollection = @()
-#retrieve any m 365 group associated with Microsoft teams
-$m365Groups = Get-PnPMicrosoft365Group | where-object {$_.HasTeam -eq $true}
-$m365Groups | ForEach-Object{
-$ExportVw = New-Object PSObject
-$ExportVw | Add-Member -MemberType NoteProperty -name "Group Name" -value $_.DisplayName
-$m365GroupOwnersName="";
-$m365GroupMembersName="";
- 
- #for auditing purpo
- $m365GroupOwnersName = (Get-PnPMicrosoft365GroupOwners  -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
- $m365GroupMembersName = (Get-PnPMicrosoft365GroupMembers  -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
 
- $ExportVw | Add-Member -MemberType NoteProperty -name " Group Owners" -value $m365GroupOwnersName
-  $ExportVw | Add-Member -MemberType NoteProperty -name " Group Members" -value $m365GroupMembersName
- $m365GroupCollection += $ExportVw
+# Retrieve all M365 groups associated with Microsoft teams
+$m365Groups = Get-PnPMicrosoft365Group | where-object {$_.HasTeam -eq $true}
+
+$m365Groups | ForEach-Object {
+    $ExportVw = New-Object PSObject
+    $ExportVw | Add-Member -MemberType NoteProperty -name "Group Name" -value $_.DisplayName
+    $m365GroupOwnersName="";
+    $m365GroupMembersName="";
+    
+    # For auditing purpose
+    $m365GroupOwnersName = (Get-PnPMicrosoft365GroupOwner -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
+    $m365GroupMembersName = (Get-PnPMicrosoft365GroupMember -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
+
+    $ExportVw | Add-Member -MemberType NoteProperty -name "Group Owners" -value $m365GroupOwnersName
+    $ExportVw | Add-Member -MemberType NoteProperty -name "Group Members" -value $m365GroupMembersName
+    $m365GroupCollection += $ExportVw
 }
 
-#Export the result Array to CSV file
+# Export the result array to CSV file
 $m365GroupCollection | sort "Group Name" |Export-CSV $OutPutView -Force -NoTypeInformation
+
+# Disconnect SharePoint online connection
 Disconnect-PnPOnline
+
 ```
+
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+
+$dateTime = (Get-Date).toString("dd-MM-yyyy")
+$directorypath = "D:\dtemp"
+$fileName = "MSTeamsUsersReport-" + $dateTime + ".csv"
+$OutPutView = $directorypath + "\"+ $fileName
+
+# Array to hold results - PSObjects
+$msTeamsUsersCollection = @()
+
+# Get Credentials to connect
+$m365Status = m365 status
+if ($m365Status -match "Logged Out") {
+    m365 login
+}
+
+# Retrieve all teams in Microsoft Teams
+$msTeams = m365 teams team list | ConvertFrom-Json
+
+$msTeams | ForEach-Object {
+	$ExportVw = New-Object PSObject
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Team Name" -value $_.displayName
+	$teamOwnerNames = "";
+	$teamMemberNames = "";
+	$teamGuestNames = "";
+	
+	$teamOwnerNames = (m365 teams user list --teamId $_.id --role Owner | ConvertFrom-Json | select -ExpandProperty displayName) -join ";"
+	$teamMemberNames = (m365 teams user list --teamId $_.id --role Member | ConvertFrom-Json | select -ExpandProperty displayName) -join ";"
+	$teamGuestNames = (m365 teams user list --teamId $_.id --role Guest | ConvertFrom-Json | select -ExpandProperty displayName) -join ";"
+	
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Team Owners" -value $teamOwnerNames
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Team Members" -value $teamMemberNames
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Team Guests" -value $teamGuestNames
+	$msTeamsUsersCollection += $ExportVw
+}
+
+# Export the results to CSV file
+$msTeamsUsersCollection | sort "Team Name" |Export-CSV $OutPutView -Force -NoTypeInformation
+
+# Disconnect M365 connection
+m365 logout
+
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
 
 ***
 
@@ -54,6 +109,7 @@ Disconnect-PnPOnline
 | Author(s) |
 |-----------|
 | Reshmee Auckloo |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/about) |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/teams-list-teams-owners-and-members/assets/sample.json
+++ b/scripts/teams-list-teams-owners-and-members/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "List all Microsoft Teams team's Owners and Members",
     "url": "https://pnp.github.io/script-samples/teams-list-teams-owners-and-members/README.html",
     "creationDateTime": "2021-03-20",
-    "updateDateTime": "2021-10-11",
+    "updateDateTime": "2023-05-23",
     "shortDescription": "This script allows you to list all Teams team's owners and members and export them into a CSV file.",
     "longDescription": null,
     "products": [
@@ -24,12 +24,21 @@
       "Disconnect-PnPOnline",
       "Get-PnPMicrosoft365Group",
       "Get-PnPMicrosoft365GroupMember",
-      "Get-PnPMicrosoft365GroupOwner"
+      "Get-PnPMicrosoft365GroupOwner",
+      "m365 status",
+      "m365 login",
+      "m365 teams team list",
+      "m365 teams user list",
+      "m365 logout"
     ],
     "metadata": [
       {
         "key": "PNP-POWERSHELL",
-        "value": "1.5.0"
+        "value": "2.1.1"
+      },
+      {
+        "key":"CLI-FOR-MICROSOFT365",
+        "value":"6.7.0"
       }
     ],
     "thumbnails": [
@@ -47,6 +56,12 @@
         "company": "",
         "pictureUrl": "https://avatars.githubusercontent.com/u/7693852?v=4",
         "name": "Reshmee Auckloo"
+      },
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
       }
     ],
     "references": [
@@ -54,6 +69,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Update PnP PowerShell script to list all Microsoft Teams team's owners and members
- Added CLI for Microsoft 365 script to list all Microsoft Teams team's owners and members