### PR TITLE
Sample Update - Create Library and add custom Content Type

### DIFF
--- a/scripts/spo-create-library-add-contenttype/README.md
+++ b/scripts/spo-create-library-add-contenttype/README.md
@@ -6,7 +6,7 @@ plugin: add-to-gallery
 
 ## Summary
 
-The script will create a SharePoint library by checking whether it exists or not. Adds custom Content Type to the library and make it as a default content type.
+This sample script creates a SharePoint document library by checking whether it exists or not. Adds custom content type to the document library and makes it as a default content type.
 
 # [PnP PowerShell](#tab/pnpps)
 
@@ -23,7 +23,7 @@ function CreateLibraryWithCT {
     else {
         #Creating library with Document library template
         New-PnPList -Title $LibraryName -Template DocumentLibrary
-        Write-Host "Created Library " $LibraryName -ForegroundColor Green
+        Write-Host "Created Library: " $LibraryName -ForegroundColor Green
     }
 
     $ctExist = Get-PnPContentType $ctName -ErrorAction SilentlyContinue
@@ -33,8 +33,8 @@ function CreateLibraryWithCT {
     else {
         $ctExist = Add-PnPContentType -Name $ctName `
             -Group "Custom Content Types" `
-            -Description "My custom ct"
-        Write-Host "Created Content Type " $ctName -ForegroundColor Green
+            -Description "My Custom CT description"
+        Write-Host "Created Content Type: " $ctName -ForegroundColor Green
     }
 
     #region Adding, setting default content type and remove existing CT
@@ -47,7 +47,7 @@ function CreateLibraryWithCT {
 try {
     $clientId = ""
     $clientSecret = ""
-    $siteUrl = ""
+    $siteUrl = "https://contoso.sharepoint.com/sites/PnPPowerShell"
     Connect-PnPOnline -Url $siteUrl -ClientId $clientId -ClientSecret $clientSecret
 
     CreateLibraryWithCT -LibraryName "My Lib"
@@ -66,11 +66,82 @@ finally {
 
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+
+function CreateLibraryWithCT {
+    param ([string] $LibraryName)
+
+    # Set Variables
+    $siteUrl = "https://contoso.sharepoint.com/sites/CLIForMicrosoft365"
+    $ctName = "My Custom CT"
+    $ctId = "0x010100CD5BDB7DDE03324794E155CE37E4B6BB"
+
+    # Check if document library already exists
+    $libExist = m365 spo list get --webUrl $siteUrl --title $LibraryName | ConvertFrom-Json
+    if ($libExist) {
+        Write-Host "Document Library - $LibraryName already exists" -ForegroundColor Yellow
+    }
+    else {
+        # Create new SharePoint document library
+        m365 spo list add --webUrl $siteUrl --title $LibraryName --baseTemplate DocumentLibrary
+        Write-Host "SharePoint Document Library Created: " $LibraryName -ForegroundColor Green
+    }
+
+    # Check if SharePoint site content type already exists    
+    $ctExist = m365 spo contenttype get --webUrl $siteUrl --name $ctName | ConvertFrom-Json
+    if ($ctExist) {
+        Write-Host "Content type - $ctName already exists" -ForegroundColor Yellow
+        $ctId = $ctExist.StringId
+    }
+    else {
+        # Create new SharePoint site content type
+        $ctExist = m365 spo contenttype add --webUrl $siteUrl --name $ctName --id $ctId --group "Custom Content Types" --description "My custom content type inherited from default document content type" | ConvertFrom-Json
+        Write-Host "Content Type Created: " $ctName -ForegroundColor Green
+    }
+
+    #region Add content type to document library, set it as a default content type and remove existing document content type
+    Write-Host "Adding content type to document library"
+    $listCT = m365 spo list contenttype add --webUrl $siteUrl --listTitle $LibraryName --id $ctId | ConvertFrom-Json
+    
+    Write-Host "Setting as default content type"
+    m365 spo list contenttype default set --webUrl $siteUrl --listTitle $LibraryName --contentTypeId $listCT.StringId
+    
+    Write-Host "Removing Document content type"
+    $listDocCT = m365 spo contenttype get --webUrl $siteUrl --listTitle $LibraryName --name "Document" | ConvertFrom-Json
+    m365 spo list contenttype remove --webUrl $siteUrl --listTitle $LibraryName --id $listDocCT.StringId
+    #endregion
+}
+
+try {
+    # Get Credentials to connect to SharePoint Online site
+    $m365Status = m365 status
+    if ($m365Status -match "Logged Out") {
+        m365 login
+    }
+
+    # Create SharePoint document library with content type
+    CreateLibraryWithCT -LibraryName "My Lib"
+}
+catch {
+    Write-Error "Something went wrong: " $_
+}
+finally {
+    # Disconnect SharePoint online site
+    m365 logout
+}
+
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+
 ## Contributors
 
 | Author(s)           |
 | ------------------- |
 | Ahamed Fazil Buhari |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/about) |
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/spo-create-library-add-contenttype" aria-hidden="true" />

--- a/scripts/spo-create-library-add-contenttype/README.md
+++ b/scripts/spo-create-library-add-contenttype/README.md
@@ -133,8 +133,8 @@ finally {
 }
 
 ```
-
 [!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+***
 
 ## Contributors
 

--- a/scripts/spo-create-library-add-contenttype/assets/sample.json
+++ b/scripts/spo-create-library-add-contenttype/assets/sample.json
@@ -3,33 +3,50 @@
     "name": "spo-create-library-add-contenttype",
     "source": "pnp",
     "title": "Create Library and add custom Content Type",
-    "shortDescription": "Script to create SharePoint library and add custom content type",
+    "shortDescription": "Script to create SharePoint document library and add custom content type",
     "url": "https://pnp.github.io/script-samples/spo-create-library-add-contenttype/README.html",
     "longDescription": [
-      "Script to create SharePoint library and add custom content type"
+      "Script to create SharePoint document library and add custom content type"
     ],
     "creationDateTime": "2023-08-22",
-    "updateDateTime": "2023-08-22",
-    "products": ["SharePoint"],
+    "updateDateTime": "2023-09-12",
+    "products": [
+      "SharePoint"
+    ],
     "metadata": [
       {
         "key": "PNP-POWERSHELL",
         "value": "2.2.0"
       },
       {
-        "key": "POWERSHELL",
-        "value": "7.2.0"
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "6.11.0"
       }
     ],
-    "categories": ["Provision"],
+    "categories": [
+      "Provision"
+    ],
     "tags": [
+      "Connect-PnPOnline",
+      "Get-PnPConnection",
+      "Disconnect-PnPOnline",
       "Get-PnPList",
       "New-PnPList",
       "Get-PnPContentType",
       "Add-PnPContentType",
       "Add-PnPContentTypeToList",
       "Set-PnPDefaultContentTypeToList",
-      "Remove-PnPContentTypeFromList"
+      "Remove-PnPContentTypeFromList",
+      "m365 status",
+      "m365 login",
+      "m365 logout",
+      "m365 spo list get",
+      "m365 spo list add",
+      "m365 spo contenttype get",
+      "m365 spo contenttype add",
+      "m365 spo list contenttype add",
+      "m365 spo list contenttype default set",
+      "m365 spo list contenttype remove"
     ],
     "thumbnails": [
       {
@@ -40,6 +57,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
+      },
       {
         "gitHubAccount": "ahamedfazil",
         "company": "",
@@ -52,6 +75,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Added CLI for Microsoft 365 script sample that creates a SharePoint document library by checking whether it exists or not. Adds custom content type to the document library and makes it as a default content type.