### PR TITLE
Sample Update - Enable/Disable Search Crawling on Sites and Libraries

### DIFF
--- a/scripts/spo-enable-disable-search-crawling/README.md
+++ b/scripts/spo-enable-disable-search-crawling/README.md
@@ -6,10 +6,10 @@ plugin: add-to-gallery
 
 ## Summary
 
-This sample allows you to enable or disable Search crawling on site or a library. You can use this to control the search indexing of a site or library but if you disable, web parts and search experiences will not work against the locations you disable. However, this can be used to remove locations from Microsoft 365 Copilot. 
+This sample allows you to enable or disable the Search crawling on a site or a library. You can use this to control the search indexing of a site or a library. But if you disable it, web parts and search experiences will not work against the locations you disable. However, this can be used to remove locations from Microsoft 365 Copilot. 
 
 > [!Warning]
-> Please be aware this script contains a command that will remove content from search, ensure you test and understand the implications of running the script. If this is an active site, you can negatively impact the user experience.
+> Please be aware this script contains a command that will remove content from search, ensure you test and understand the implications of running the script. If this is an active site, it can negatively impact the user experience.
 
 
 ![Example Screenshot](assets/example.png)
@@ -18,13 +18,14 @@ This sample allows you to enable or disable Search crawling on site or a library
 
 ```powershell
 
+# Connect to SharePoint Online site
 Connect-PnPOnline https://contoso.sharepoint.com/sites/SearchEnableDisableTest -Interactive
 
 # Note: No Search Crawl is false because it is crawling the site by default - love these MS negative logic
 $status = Get-PnPWeb -Includes NoCrawl
-Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)" 
+Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
 
-# Disable Search No Site Scripting
+# Disable No Site Scripting
 # If you don't do this, you may get an access denied error
 Set-PnPSite -NoScriptSite $false
 
@@ -40,9 +41,9 @@ Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
 Set-PnPWeb -NoCrawl:$false
 
 $status = Get-PnPWeb -Includes NoCrawl
-Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)" 
+Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
 
-# Enable Search No Site Scripting
+# Enable No Site Scripting
 Set-PnPSite -NoScriptSite $true
 
 #-----------------------------------------------------------
@@ -54,33 +55,110 @@ $listName = "Documents"
 
 # Get the current status of the list
 $list = Get-PnPList -Identity $listName -Includes NoCrawl
-Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)" 
+Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)"
 
 # Disable Search Crawl on list
 #-------------------------------
 Set-PnPList -Identity $listName -NoCrawl
 
 $list = Get-PnPList -Identity $listName -Includes NoCrawl
-Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)" 
-
+Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)"
 
 # Enable Search Crawl on list
 #-------------------------------
 Set-PnPList -Identity $listName -NoCrawl:$false
 
 $list = Get-PnPList -Identity $listName -Includes NoCrawl
-Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)"   
+Write-Host "Current DOCUMENT LIBRARY ($($listName)) status - Crawling: $(!$list.NoCrawl)"  
+
+# Disconnect SharePoint online connection
+Disconnect-PnPOnline
 
 ```
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
-***
 
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+
+# Get Credentials to connect
+$m365Status = m365 status
+if ($m365Status -match "Logged Out") {
+    m365 login
+}
+
+# SharePoint online site URL
+$siteUrl = Read-Host -Prompt "Enter your SharePoint site URL (e.g https://contoso.sharepoint.com/sites/SearchEnableDisableTest)"
+
+# Note: No Search Crawl is false because it is crawling the site by default - love these MS negative logic
+$status = m365 spo web get --url $siteUrl | ConvertFrom-Json
+Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
+
+# Disable No Site Scripting
+# If you don't do this, you may get an access denied error
+m365 spo site set --url $siteUrl --noScriptSite false
+
+# Disable Search Crawl
+#----------------------------
+
+m365 spo web set --url $siteUrl --NoCrawl true
+
+$status = m365 spo web get --url $siteUrl | ConvertFrom-Json
+Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
+
+# Enable Search Crawl
+#----------------------------
+
+m365 spo web set --url $siteUrl --NoCrawl false
+
+$status = m365 spo web get --url $siteUrl | ConvertFrom-Json
+Write-Host "Current WEB status - Crawling: $(!$status.NoCrawl)"
+
+# Enable No Site Scripting
+m365 spo site set --url $siteUrl --noScriptSite true
+
+#-----------------------------------------------------------
+# Library Level
+#-----------------------------------------------------------
+
+# Remember - No Search Crawl is false because it is crawling the site by default
+$libraryName = "Documents"
+
+# Get the current status of the list/library
+$library = m365 spo list get --title $libraryName --webUrl $siteUrl | ConvertFrom-Json
+Write-Host "Current DOCUMENT LIBRARY ($($libraryName)) status - Crawling: $(!$library.NoCrawl)"
+
+# Disable Search Crawl on list/library
+#-------------------------------
+
+m365 spo list set --webUrl $siteUrl --title $libraryName --noCrawl true
+
+$library = m365 spo list get --title $libraryName --webUrl $siteUrl | ConvertFrom-Json
+Write-Host "Current DOCUMENT LIBRARY ($($libraryName)) status - Crawling: $(!$library.NoCrawl)"
+
+# Enable Search Crawl on list
+#-------------------------------
+
+m365 spo list set --webUrl $siteUrl --title $libraryName --noCrawl false
+
+$library = m365 spo list get --title $libraryName --webUrl $siteUrl | ConvertFrom-Json
+Write-Host "Current DOCUMENT LIBRARY ($($libraryName)) status - Crawling: $(!$library.NoCrawl)"
+
+# Disconnect SharePoint online connection
+m365 logout
+
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+
+***
 
 ## Contributors
 
 | Author(s) |
 |-----------|
 | Paul Bullock |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/about) |
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/spo-enable-disable-search-crawling" aria-hidden="true" />

--- a/scripts/spo-enable-disable-search-crawling/assets/sample.json
+++ b/scripts/spo-enable-disable-search-crawling/assets/sample.json
@@ -9,7 +9,7 @@
       ""
     ],
     "creationDateTime": "2023-11-13",
-    "updateDateTime": "2023-11-13",
+    "updateDateTime": "2023-11-27",
     "products": [
       "SharePoint",
       "Microsoft 365 Copilot"
@@ -18,19 +18,31 @@
       {
         "key": "PNP-POWERSHELL",
         "value": "1.11.0"
+      },
+      {
+        "key":"CLI-FOR-MICROSOFT365",
+        "value":"7.0.0"
       }
     ],
     "categories": [
-      "Modernize",
-      "Data",
-      "Deploy",
-      "Provision",
-      "Configure",
-      "Report",
-      "Security"
+      "Configure"
     ],
     "tags": [
-      "<Cmdlets-Used>"
+      "Connect-PnPOnline",
+      "Get-PnPWeb",
+      "Set-PnPSite",
+      "Set-PnPWeb",
+      "Get-PnPList",
+      "Set-PnPList",
+      "Disconnect-PnPOnline",
+      "m365 status",
+      "m365 login",
+      "m365 spo web get",
+      "m365 spo site set",
+      "m365 spo web set",
+      "m365 spo list get",
+      "m365 spo list set",
+      "m365 logout"
     ],
     "thumbnails": [
       {
@@ -41,6 +53,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
+      },
       {
         "gitHubAccount": "pkbullock",
         "company": "",
@@ -53,6 +71,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Added CLI for Microsoft 365 script sample that will allow you to enable or disable the Search crawling on a SharePoint site or a library.