### PR TITLE
Sample Update - Export Content Type Details To CSV

### DIFF
--- a/scripts/spo-export-content-type-details-to-csv/README.md
+++ b/scripts/spo-export-content-type-details-to-csv/README.md
@@ -5,28 +5,28 @@ plugin: add-to-gallery
 # Export Content Type Details To CSV
 
 ## Summary
-This example illustrates how to export all content types present on websites, capturing essential details like Name, ID, Scope, Schema, Fields, and additional information, then organizing them into a CSV format.
+
+This example illustrates how to export all content types present on a SharePoint site, capturing essential details like Name, ID, Scope, Schema, Fields, and additional information, then organizing them into a CSV format.
 
 # [PnP PowerShell](#tab/pnpps)
 
 ```powershell
-
 $siteUrl = Read-Host "Enter site URL"
 $username = "username@domain.onmicrosoft.com"
 $password = "********"
-$secureStringPwd = $password | ConvertTo-SecureString -AsPlainText -Force 
+$secureStringPwd = $password | ConvertTo-SecureString -AsPlainText -Force
 $creds = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $secureStringPwd
-$dateTime = "{0:MM_dd_yy}{0:HH_mm_ss}" -f (Get-Date)
+$dateTime = "{0:MM_dd_yy}_{0:HH_mm_ss}" -f (Get-Date)
 $basePath = "D:\Contributions\Scripts\Logs\"
 $csvPath = $basePath + "\ContentTypeData" + $dateTime + ".csv"
 $global:ctData = @()
 
 Function Login() {
     [cmdletbinding()]
-    param([parameter(Mandatory = $true, ValueFromPipeline = $true)] $creds)     
-    Write-Host "Connecting to Site '$($siteUrl)'" -ForegroundColor Yellow   
+    param([parameter(Mandatory = $true, ValueFromPipeline = $true)] $creds)
+    Write-Host "Connecting to Site '$($siteUrl)'" -ForegroundColor Yellow
     Connect-PnPOnline -Url $siteUrl -Credentials $creds
-    Write-Host "Connection Successful!" -ForegroundColor Green     
+    Write-Host "Connection Successful!" -ForegroundColor Green
 }
 
 Function ContentTypeDetails() {
@@ -38,56 +38,132 @@ Function ContentTypeDetails() {
             #Collect Content Type Data
             $ctName = $contentType.Name
             $ctId = $contentType.Id
-            $ctGroup = $contentType.Group  
-            $ctDescription = $contentType.Description  
-            $ctPath = $contentType.Path  
-            $ctScope = $contentType.Scope  
-            $ctStringId = $contentType.StringId  
-            $ctSchemaXml = $contentType.SchemaXml  
+            $ctGroup = $contentType.Group
+            $ctDescription = $contentType.Description
+            $ctPath = $contentType.Path
+            $ctScope = $contentType.Scope
+            $ctStringId = $contentType.StringId
+            $ctSchemaXml = $contentType.SchemaXml
             $contentTypeFields = Get-PnPProperty -ClientObject $contentType -Property Fields
             $contentTypeFieldsCount = $contentTypeFields.Count
             $contentTypeFieldsSchema = $contentTypeFields.SchemaXml
             $contentTypeTitle = ($contentTypeFields | select-object -property Title | foreach-object { $_.Title }) -join ','
             
             $global:ctData += [PSCustomObject] @{
-                Name               = $ctName
-                ID                 = $ctId
-                Group              = $ctGroup
-                Description        = $ctDescription
-                Path               = $ctPath
-                Scope              = $ctScope
-                StringId           = $ctStringId
-                SchemaXml          = $ctSchemaXml
-                Fields             = $contentTypeTitle
-                FieldCount         = $contentTypeFieldsCount
-                FieldSchemaXMl     = $contentTypeFields.SchemaXml
+                Name                = $ctName
+                ID                  = $ctId
+                Group               = $ctGroup
+                Description         = $ctDescription
+                Path                = $ctPath
+                Scope               = $ctScope
+                StringId            = $ctStringId
+                SchemaXml           = $ctSchemaXml
+                Fields              = $contentTypeTitle
+                FieldCount          = $contentTypeFieldsCount
+                FieldSchemaXMl      = $contentTypeFields.SchemaXml
             }
-        }    
-        Write-Host "Getting content type details successfully!..." -ForegroundColor Green  
+        }
+        Write-Host "Getting content type details successfully!..." -ForegroundColor Green
     }
     catch {
-        Write-Host "Error in getting content type information:" $_.Exception.Message -ForegroundColor Red                 
-    }    
-    Write-Host "Exporting to CSV..."  -ForegroundColor Yellow 
+        Write-Host "Error in getting content type information:" $_.Exception.Message -ForegroundColor Red
+    }
+    Write-Host "Exporting to CSV..."  -ForegroundColor Yellow
     $global:ctData | Export-Csv $csvPath -NoTypeInformation -Append
-    Write-Host "Exported to CSV successfully!..."  -ForegroundColor Gree
+    Write-Host "Exported to CSV successfully!..."  -ForegroundColor Green
+
+    # Disconnect SharePoint online connection
+    Disconnect-PnPOnline
 }
 
 Function StartProcessing {
-    Login($creds);  
-    ContentTypeDetails 
+    Login($creds);
+    ContentTypeDetails
 }
 
 StartProcessing
 ```
+
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+$siteUrl = Read-Host -Prompt "Enter your SharePoint online site URL (e.g https://contoso.sharepoint.com/sites/work)"
+$dateTime = "{0:MM_dd_yy}_{0:HH_mm_ss}" -f (Get-Date)
+$basePath = "D:\dtemp\"
+$csvPath = $basePath + "\ContentTypesData" + $dateTime + ".csv"
+$global:ctData = @()
+
+Function Login() {     
+    Write-Host "Connecting to SharePoint" -ForegroundColor Yellow
+	
+	#Get Credentials to connect
+	$m365Status = m365 status
+	if ($m365Status -match "Logged Out") {
+		m365 login
+	}
+    
+	Write-Host "Connection Successful!" -ForegroundColor Green
+}
+
+Function ContentTypeDetails() {
+    try {
+        Write-Host "Getting content type details..." -ForegroundColor Yellow
+		$allContentTypes = m365 spo contenttype list --webUrl $siteUrl | ConvertFrom-Json
+
+        Foreach ($contentType in $allContentTypes)
+        {
+            #Collect Content Type Data
+            $ctName = $contentType.Name
+            $ctId = $contentType.Id
+            $ctGroup = $contentType.Group
+			$ctDescription = $contentType.Description
+            $ctScope = $contentType.Scope
+            $ctStringId = $contentType.StringId
+            $ctSchemaXml = $contentType.SchemaXml
+            
+            $global:ctData += [PSCustomObject] @{
+                Name            = $ctName
+                ID              = $ctId.StringValue
+                Group			= $ctGroup
+                Description		= $ctDescription
+                Scope			= $ctScope
+                StringId		= $ctStringId
+                SchemaXml		= $ctSchemaXml
+            }
+        }
+        Write-Host "Getting content type details successfully!..." -ForegroundColor Green
+    }
+    catch {
+        Write-Host "Error in getting content type information:" $_.Exception.Message -ForegroundColor Red
+    }
+    Write-Host "Exporting to CSV..."  -ForegroundColor Yellow
+    $global:ctData | Export-Csv $csvPath -NoTypeInformation -Append
+    Write-Host "Exported to CSV successfully!..."  -ForegroundColor Green
+	
+	# Disconnect SharePoint online connection
+	m365 logout
+}
+
+Function StartProcessing {
+	Login
+    ContentTypeDetails
+}
+
+StartProcessing
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+
 ***
+
 ## Contributors
 
 | Author(s) |
 |-----------|
 | Chandani Prajapati (https://github.com/chandaniprajapati) |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/) |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/spo-export-content-type-details-to-csv/assets/sample.json
+++ b/scripts/spo-export-content-type-details-to-csv/assets/sample.json
@@ -3,13 +3,13 @@
     "name": "spo-export-content-type-details-to-csv",
     "source": "pnp",
     "title": "Export Content Type Details To CSV",
-    "shortDescription": "This script exports all content types available on sites to CSV.",
+    "shortDescription": "This script exports all content types available on a SharePoint site to CSV.",
     "url": "https://pnp.github.io/script-samples/spo-export-content-type-details-to-csv/README.html",
     "longDescription": [
-      "This script exports all content types available on sites, including basic information such as Name, ID, Scope, Schema, Fields, and more, into a CSV format."
+      "This script exports all content types available on a SharePoint site, including basic information such as Name, ID, Scope, Schema, Fields, and more, into a CSV format."
     ],
     "creationDateTime": "2024-03-05",
-    "updateDateTime": "2024-03-05",
+    "updateDateTime": "2024-03-09",
     "products": [
       "SharePoint"
     ],
@@ -17,6 +17,10 @@
       {
         "key": "PNP-POWERSHELL",
         "value": "2.3.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "7.5.0"
       }
     ],
     "categories": [
@@ -28,17 +32,28 @@
       "Connect-PnPOnline",
       "Get-PnPContentType",
       "Get-PnPProperty",
-      "Export-Csv"
+      "Export-Csv",
+      "Disconnect-PnPOnline",
+      "m365 status",
+      "m365 login",
+      "m365 spo contenttype list",
+      "m365 logout"
     ],
     "thumbnails": [
       {
         "type": "image",
         "order": 100,
         "url": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-content-type-details-to-csv/assets/preview.png",
-        "alt": "Preview of the sample <title>"
+        "alt": "Preview of the sample Export Content Type Details To CSV"
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
+      },
       {
         "gitHubAccount": "chandaniprajapati",
         "company": "Rapid Circle",
@@ -51,6 +66,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Added CLI for Microsoft 365 script samples that exports all content types available on a SharePoint site, including basic information such as Name, ID, Scope, Schema, Fields, and more, into a CSV format.