### PR TITLE
Sample Update - Replace an owner in a Microsoft 365 Group or Microsoft Team

### DIFF
--- a/scripts/aad-replace-owner-with-a-different-one/README.md
+++ b/scripts/aad-replace-owner-with-a-different-one/README.md
@@ -6,14 +6,16 @@ plugin: add-to-gallery
 
 ## Summary
 
-Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone else useful for when an employee leaves and ownership needs to be updated.
- 
+Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone else useful for when an employee leaves and ownership needs to be updated. 
 
 # [PnP PowerShell](#tab/pnpps)
+
 ```powershell
-$AdminCenterURL="https://contoso-admin.sharepoint.com/"
+$AdminCenterURL = "https://contoso-admin.sharepoint.com/"
+
 $oldOwnerUPN = Read-Host "Enter the old owner UPN to be replaced with" #testUser1@contose.onmicrosoft.com
-$newOwnerUPN = Read-Host "Enter the new owner UPN to  replace with" #testuser2@contoso.onmicrosoft.com
+$newOwnerUPN = Read-Host "Enter the new owner UPN to replace with" #testuser2@contoso.onmicrosoft.com
+
 #Connect to SharePoint Online admin center
 Connect-PnPOnline -Url $AdminCenterURL -Interactive
 
@@ -24,42 +26,112 @@ $fileName = "m365GroupOwnersReport-" + $dateTime + ".csv"
 $OutPutView = $directorypath + "\Logs\"+ $fileName
 
 #Array to Hold Result - PSObjects
-
 $m365GroupCollection = @()
-#retrieve any m 365 group starting with Permission
+
+#Retrieve any m 365 group starting with Permission
 $m365Groups = Get-PnPMicrosoft365Group | where-object {$_.DisplayName -like "Permission*"}
-$m365Groups | ForEach-Object{
-$ExportVw = New-Object PSObject
-$ExportVw | Add-Member -MemberType NoteProperty -name "Group Name" -value $_.DisplayName
-$m365GroupOwnersName="";
- try
-  {
-   $oldOwner = Get-PnPMicrosoft365GroupOwners  -Identity $_.GroupId | where-object {$_.Email -eq $oldOwnerUPN}
 
-   if($oldOwner)
-   {
-    #replace old owner with new owner
-    Remove-PnPMicrosoft365GroupOwner -Identity $_.GroupId -Users $oldOwner.Email;
-    Add-PnPMicrosoft365GroupOwner -Identity $_.GroupId -Users $newOwnerUPN;
-   }
- }
-catch
-  {
-  write-host $("Error occured to update group " + $_.DisplayName + $Error)
-  }
+$m365Groups | ForEach-Object {
+	$ExportVw = New-Object PSObject
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Group Name" -value $_.DisplayName
+	$m365GroupOwnersName = "";
+	
+  	try
+  	{
+    	$oldOwner = Get-PnPMicrosoft365GroupOwners  -Identity $_.GroupId | where-object {$_.Email -eq $oldOwnerUPN}
 
- #for auditing purposes
- $m365GroupOwnersName = (Get-PnPMicrosoft365GroupOwners  -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
+    	if($oldOwner)
+    	{
+			#Replace old owner with new owner
+			Remove-PnPMicrosoft365GroupOwner -Identity $_.GroupId -Users $oldOwner.Email;
+			Add-PnPMicrosoft365GroupOwner -Identity $_.GroupId -Users $newOwnerUPN;
+    	}
+  	}
+  	catch
+  	{
+    	write-host $("Error occured to update group " + $_.DisplayName + $Error)
+  	}
 
- $ExportVw | Add-Member -MemberType NoteProperty -name " Group Owners" -value $m365GroupOwnersName
- $m365GroupCollection += $ExportVw
+  	#For auditing purposes - get owners of the group
+  	$m365GroupOwnersName = (Get-PnPMicrosoft365GroupOwners  -Identity $_.GroupId | select -ExpandProperty DisplayName) -join ";";
+
+	$ExportVw | Add-Member -MemberType NoteProperty -name " Group Owners" -value $m365GroupOwnersName
+	$m365GroupCollection += $ExportVw
 }
 
 #Export the result Array to CSV file
 $m365GroupCollection | sort "Group Name" |Export-CSV $OutPutView -Force -NoTypeInformation
+
+# Disconnect PnP online connection
 Disconnect-PnPOnline
 ```
+
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+$oldOwnerUPN = Read-Host "Enter the old owner UPN to be replaced with" #testUser1@contose.onmicrosoft.com
+$newOwnerUPN = Read-Host "Enter the new owner UPN to replace with" #testuser2@contoso.onmicrosoft.com
+
+#Get Credentials to connect
+$m365Status = m365 status
+if ($m365Status -match "Logged Out") {
+    m365 login
+}
+
+$dateTime = (Get-Date).toString("dd-MM-yyyy")
+$invocation = (Get-Variable MyInvocation).Value
+$directorypath = Split-Path $invocation.MyCommand.Path
+$fileName = "m365GroupOwnersReport-" + $dateTime + ".csv"
+$OutPutView = $directorypath + "\Logs\"+ $fileName
+
+#Array to Hold Result - PSObjects
+$m365GroupCollection = @()
+
+#Retrieve any M365 group starting with "Permission" (you can use filter as per your requirements)
+$m365Groups = m365 entra m365group list --displayName Permission | ConvertFrom-Json
+
+$m365Groups | ForEach-Object {
+	$ExportVw = New-Object PSObject
+	$ExportVw | Add-Member -MemberType NoteProperty -name "Group Name" -value $_.displayName
+	$m365GroupOwnersName = "";
+	
+	try
+	{
+		#Check if old user is an owner of the group
+		$oldOwner = m365 entra m365group user list --groupId $_.id --role Owner --filter "userPrincipalName eq '$($oldOwnerUPN)'"
+
+		if($oldOwner)
+		{
+			#Add new user as an owner of the group
+			m365 entra m365group user add --groupId $_.id --userName $newOwnerUPN --role Owner
+			
+			#Remove old user from the group
+			m365 entra m365group user remove --groupId $_.id --userName $oldOwnerUPN --force
+		}
+	}
+	catch
+	{
+		write-host $("Error occured while updating the group " + $_.displayName + $Error)
+	}
+	
+	#For auditing purposes - get owners of the group
+	$m365GroupOwnersName = (m365 entra m365group user list --groupId $_.id --role Owner | ConvertFrom-Json | select -ExpandProperty displayName) -join ";";
+
+	$ExportVw | Add-Member -MemberType NoteProperty -name " Group Owners" -value $m365GroupOwnersName
+	$m365GroupCollection += $ExportVw
+}
+
+#Export the result Array to CSV file
+$m365GroupCollection | sort "Group Name" |Export-CSV $OutPutView -Force -NoTypeInformation
+
+#Disconnect online connection
+m365 logout
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+
 ***
 
 ## Contributors
@@ -67,6 +139,7 @@ Disconnect-PnPOnline
 | Author(s) |
 |-----------|
 | Reshmee Auckloo |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/) |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/aad-replace-owner-with-a-different-one/assets/sample.json
+++ b/scripts/aad-replace-owner-with-a-different-one/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "Replace an owner in a Microsoft 365 Group or Microsoft Team",
     "url": "https://pnp.github.io/script-samples/aad-replace-owner-with-a-different-one/README.html",
     "creationDateTime": "2021-05-04",
-    "updateDateTime": "2021-10-11",
+    "updateDateTime": "2024-03-10",
     "shortDescription": "Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone",
     "longDescription": null,
     "products": [
@@ -28,12 +28,23 @@
       "Get-PnPMicrosoft365Group",
       "Get-PnPMicrosoft365GroupOwner",
       "Remove-PnPMicrosoft365Group",
-      "Remove-PnPMicrosoft365GroupOwner"
+      "Remove-PnPMicrosoft365GroupOwner",
+      "m365 login",
+      "m365 status",
+      "m365 entra m365group list",
+      "m365 entra m365group user list",
+      "m365 entra m365group user add",
+      "m365 entra m365group user remove",
+      "m365 logout"
     ],
     "metadata": [
       {
         "key": "PNP-POWERSHELL",
         "value": "1.5.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "7.5.0"
       }
     ],
     "thumbnails": [
@@ -41,11 +52,17 @@
         "type": "image",
         "order": 100,
         "url": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-replace-owner-with-a-different-one/assets/preview.png",
-        "alt": "preview image for the sample",
+        "alt": "preview image for the sample Replace an owner in a Microsoft 365 Group or Microsoft Team",
         "slides": null
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
+      },
       {
         "gitHubAccount": "reshmee011",
         "company": "",
@@ -58,6 +75,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Added CLI for Microsoft 365 script samples that finds all the Microsoft 365 Groups that a user is an Owner of and replace them with someone else, it is useful when an employee leaves and ownership needs to be updated.