### PR TITLE
Sample Update - Delete all Microsoft 365 groups and SharePoint sites

### DIFF
--- a/scripts/aad-delete-m365-groups-and-sharepoint-sites/README.md
+++ b/scripts/aad-delete-m365-groups-and-sharepoint-sites/README.md
@@ -6,46 +6,86 @@ plugin: add-to-gallery
 
 ## Summary
 
-Another example how you can delete all Microsoft 365 Groups and SharePoint Online sites in your development environment.
+This script sample shows how you can delete Microsoft 365 Groups and associated SharePoint Online sites in your development environment.
  
 [!INCLUDE [Delete Warning](../../docfx/includes/DELETE-WARN.md)]
 
-
 # [PnP PowerShell](#tab/pnpps)
+
 ```powershell
 $AdminCenterURL="https://contoso-admin.sharepoint.com/"
-#Connect to SharePoint admin url using PnPOnline to use PnP cmdlets to delete m365 groups and SharePoint sites
+
+#Connect to SharePoint admin URL using PnPOnline to use PnP cmdlets to delete M365 groups and SharePoint sites
 Connect-PnPOnline -Url $AdminCenterURL -Interactive
 
-#retrieve all m365 group connected ( template "GROUP#0" sites to be deleted) sites beginning with https://contoso.sharepoint.com/sites/D-Test
+#Retrieve all M365 group connected (template "GROUP#0" sites to be deleted) sites beginning with https://contoso.sharepoint.com/sites/D-Test
 $sites = Get-PnPTenantSite -Filter {Url -like https://contoso.sharepoint.com/sites/D-Test} -Template 'GROUP#0'
 
-#displaying the sites returned to be deleted
-$sites | Format-Table  Url, Template , GroupId
+#Displaying the sites returned to be deleted
+$sites | Format-Table  Url, Template, GroupId
 
 Read-Host -Prompt "Press Enter to start deleting m365 groups and sites (CTRL + C to exit)"
-$sites | ForEach-Object{
-Remove-PnPMicrosoft365Group  -Identity $_.GroupId
-#allow time for m365 group to be deleted
-Start-Sleep -Seconds 60
-#delete the SharePoint site after the m365 group is deleted
-Remove-PnPTenantSite -Url $_.Url -Force -SkipRecycleBin
-#permanently remove the m365 group
-Remove-PnPDeletedMicrosoft365Group -Identity $_.GroupId
 
-#permanently delete the site and to allow a site to be created with the url of the site just deleted , i.e. to avoid message "This site address is available with modification"
-Remove-PnPTenantDeletedSite -Identity $_.Url -Force
+$sites | ForEach-Object {
+    #Delete M365 group
+    Remove-PnPMicrosoft365Group -Identity $_.GroupId
+
+    #Allow time for M365 group to be deleted
+    Start-Sleep -Seconds 60
+
+    #Delete the SharePoint site after the M365 group is deleted
+    Remove-PnPTenantSite -Url $_.Url -Force -SkipRecycleBin
+
+    #Permanently remove the M365 group
+    Remove-PnPDeletedMicrosoft365Group -Identity $_.GroupId
+
+    #Permanently delete the site and to allow a site to be created with the same URL of the site just deleted, i.e. to avoid message "This site address is available with modification"
+    Remove-PnPTenantDeletedSite -Identity $_.Url -Force
 }
+
+# Disconnect SharePoint online connection
+Disconnect-PnPOnline
 ```
+
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [CLI for Microsoft 365](#tab/cli-m365-ps)
+
+```powershell
+#Get Credentials to connect
+$m365Status = m365 status
+if ($m365Status -match "Logged Out") {
+    m365 login
+}
+
+#Retrieve all M365 groups where display name starts with "Permission" (you can use filter as per your requirements)
+$groups = m365 entra m365group list --displayName Permission | ConvertFrom-Json
+
+#Displaying the M365 groups returned to be deleted
+$groups | Format-Table displayName, id, mail
+
+Read-Host -Prompt "Press Enter to start deleting M365 groups and associated SharePoint sites (CTRL + C to exit)"
+
+$groups | ForEach-Object {
+	#Permanently delete M365 group and associated SharePoint site without prompting for confirmation and without moving it to the Recycle Bin
+	Write-Host "Deleting M365 group: $($_.displayName)"
+	m365 entra m365group remove --id $_.id --force --skipRecycleBin
+}
+
+#Disconnect SharePoint online connection
+m365 logout
+```
+
+[!INCLUDE [More about CLI for Microsoft 365](../../docfx/includes/MORE-CLIM365.md)]
+
 ***
 
 ## Contributors
 
 | Author(s) |
 |-----------|
-| Reshmee Auckloo 
-
+| Reshmee Auckloo |
+| [Ganesh Sanap](https://ganeshsanapblogs.wordpress.com/) |
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/aad-delete-m365-groups-and-sharepoint-sites" aria-hidden="true" />

--- a/scripts/aad-delete-m365-groups-and-sharepoint-sites/assets/sample.json
+++ b/scripts/aad-delete-m365-groups-and-sharepoint-sites/assets/sample.json
@@ -7,8 +7,8 @@
     "title": "Delete all Microsoft 365 groups and SharePoint sites",
     "url": "https://pnp.github.io/script-samples/aad-delete-m365-groups-and-sharepoint-sites/README.html",
     "creationDateTime": "2021-03-15",
-    "updateDateTime": "2021-10-06",
-    "shortDescription": "Example how you can delete all Microsoft 365 Groups and SharePoint Online sites in your development environment",
+    "updateDateTime": "2024-03-10",
+    "shortDescription": "Sample shows how you can delete Microsoft 365 Groups and associated SharePoint Online sites in your development environment",
     "longDescription": null,
     "products": [
       "AzureAD",
@@ -21,17 +21,26 @@
       "SharePoint Online",
       "Microsoft 365 Groups",
       "Connect-PnPOnline",
-      "Get-PnPTenant",
       "Get-PnPTenantSite",
       "Remove-PnPDeletedMicrosoft365Group",
       "Remove-PnPMicrosoft365Group",
       "Remove-PnPTenantDeletedSite",
-      "Remove-PnPTenantSite"
+      "Remove-PnPTenantSite",
+      "Disconnect-PnPOnline",
+      "m365 login",
+      "m365 status",
+      "m365 entra m365group list",
+      "m365 entra m365group remove",
+      "m365 logout"
     ],
     "metadata": [
       {
         "key": "PNP-POWERSHELL",
         "value": "1.5.0"
+      },
+      {
+        "key": "CLI-FOR-MICROSOFT365",
+        "value": "7.5.0"
       }
     ],
     "thumbnails": [
@@ -39,11 +48,17 @@
         "type": "image",
         "order": 100,
         "url": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-delete-m365-groups-and-sharepoint-sites/assets/preview.png",
-        "alt": "preview image for the sample",
+        "alt": "preview image for the sample Delete all Microsoft 365 groups and SharePoint sites",
         "slides": null
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "ganesh-sanap",
+        "company": "",
+        "pictureUrl": "https://avatars.githubusercontent.com/u/25476310?v=4",
+        "name": "Ganesh Sanap"
+      },
       {
         "gitHubAccount": "reshmee011",
         "company": "",
@@ -56,6 +71,11 @@
         "name": "Want to learn more about PnP PowerShell and the cmdlets",
         "description": "Check out the PnP PowerShell site to get started and for the reference to the cmdlets.",
         "url": "https://aka.ms/pnp/powershell"
+      },
+      {
+        "name": "Want to learn more about CLI for Microsoft 365 and the commands",
+        "description": "Check out the CLI for Microsoft 365 site to get started and for the reference to the commands.",
+        "url": "https://aka.ms/cli-m365"
       }
     ]
   }


### PR DESCRIPTION
# What's in the pull request

- Added CLI for Microsoft 365 script samples that shows how you can delete Microsoft 365 Groups and associated SharePoint Online sites in your development environment.