### PR TITLE
Enable modern creation forms for Document sets - Added CTH variation of the script

### DIFF
--- a/scripts/spo-document-sets-modern-new-form/README.md
+++ b/scripts/spo-document-sets-modern-new-form/README.md
@@ -4,8 +4,7 @@
 
 ## Summary
 
-I've found that setting the NewFormClientSideComponentId to _NULL_ on a documents set content type will cause it to render a modern creation form over the default, this script will help you do that.
-
+I've found that setting the NewFormClientSideComponentId to _NULL_ on a documents set content type will cause it to render a modern creation form over the default, this script will help you do that. (Also see alternate version below, which works on the Content Type Hub.)
 
 ![Outupt Screenshot](assets/output.png)
 
@@ -47,6 +46,51 @@ Invoke-PnPQuery
 Write-Host -ForegroundColor Green "All done"
 
 ```
+
+This alternate version, based on Dan's script above, works on the Content Type Hub, allowing you to modernize Document Sets stored at the enterprise level. See [Modernizing the Document Set NewDocSet Form](https://sympmarc.com/2025/06/12/modernizing-the-document-set-newdocset-form/) for more details
+
+```powershell
+$tenant = "YourTenantName"
+$clientId = "YourAppRegistrationGUID"
+
+$cthConnection = Connect-PnPOnline -ClientId $clientId -Url "https://$($tenant).sharepoint.com/sites/ContentTypeHub" -Interactive
+
+# Get the "Document Set" content types
+$cts = Get-PnPContentType | Where-Object { $_.Id.StringValue.StartsWith("0x0120D520") }
+
+foreach ($ct in $cts) {
+    $currVal = "❌"
+    if($ct.NewFormClientSideComponentId.Length -eq '') {
+        $currVal = "✅"
+    }
+    Write-Host "[$($cts.IndexOf($ct)+1)] $($ct.name) $($currVal)"
+}
+
+$CTindex = Read-Host -Prompt "Which content type to you wish to modernize"
+
+# Null out the NewFormClientSideComponentId as that seems to bring it to modern UI
+$cts[$CTindex - 1].NewFormClientSideComponentId = $null;
+$cts[$CTindex - 1].Update($false);
+
+Invoke-PnPQuery
+
+$ctPub = Read-Host -Prompt "Content Type $($cts[$CTindex-1].Name) updated. Would you like to publish the change? (Y/N)"
+if ($ctPub -ne 'Y' -and $ctPub -ne 'y') {
+    Write-Host -ForegroundColor Red "Exiting without publishing changes."
+    exit
+}
+else {
+    # Publish the changed content type
+    Write-Host -ForegroundColor Yellow "Publishing content type $($cts[$CTindex-1].Name) with ID $($cts[$CTindex-1].Id)"
+    Publish-PnPContentType -ContentType $cts[$CTindex - 1].Id
+}
+
+Write-Host -ForegroundColor Green "All done"
+
+```
+
+
+
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
 
@@ -55,6 +99,8 @@ Write-Host -ForegroundColor Green "All done"
 | Author(s)                          |
 | ---------------------------------- |
 | Dan Toft(https://blog.dan-toft.dk) |
+| Marc D Anderson (https://sympmarc.com) |
+
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/spo-document-sets-modern-new-form" aria-hidden="true" />

--- a/scripts/spo-document-sets-modern-new-form/README.md
+++ b/scripts/spo-document-sets-modern-new-form/README.md
@@ -1,12 +1,10 @@
-
-
 # Enable modern creation forms for Document sets
 
 ## Summary
 
 I've found that setting the NewFormClientSideComponentId to _NULL_ on a documents set content type will cause it to render a modern creation form over the default, this script will help you do that. (Also see alternate version below, which works on the Content Type Hub.)
 
-![Outupt Screenshot](assets/output.png)
+![Output Screenshot](assets/output.png)
 
 # [PnP PowerShell](#tab/pnpps)
 
@@ -89,8 +87,6 @@ Write-Host -ForegroundColor Green "All done"
 
 ```
 
-
-
 [!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
 ***
 
@@ -98,9 +94,8 @@ Write-Host -ForegroundColor Green "All done"
 
 | Author(s)                          |
 | ---------------------------------- |
-| Dan Toft(https://blog.dan-toft.dk) |
-| Marc D Anderson (https://sympmarc.com) |
-
+| [Dan Toft](https://blog.dan-toft.dk) |
+| [Marc D Anderson](https://sympmarc.com) |
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/spo-document-sets-modern-new-form" aria-hidden="true" />

--- a/scripts/spo-document-sets-modern-new-form/README.md
+++ b/scripts/spo-document-sets-modern-new-form/README.md
@@ -44,6 +44,9 @@ Invoke-PnPQuery
 Write-Host -ForegroundColor Green "All done"
 
 ```
+[!INCLUDE [More about PnP PowerShell](../../docfx/includes/MORE-PNPPS.md)]
+
+# [PnP PowerShell Alternative](#tab/pnpps2)
 
 This alternate version, based on Dan's script above, works on the Content Type Hub, allowing you to modernize Document Sets stored at the enterprise level. See [Modernizing the Document Set NewDocSet Form](https://sympmarc.com/2025/06/12/modernizing-the-document-set-newdocset-form/) for more details
 

--- a/scripts/spo-document-sets-modern-new-form/assets/sample.json
+++ b/scripts/spo-document-sets-modern-new-form/assets/sample.json
@@ -6,7 +6,7 @@
     "url": "https://pnp.github.io/script-samples/spo-document-sets-modern-new-form/README.html",
     "longDescription": [],
     "creationDateTime": "2023-05-07",
-    "updateDateTime": "2023-05-07",
+    "updateDateTime": "2025-06-12",
     "products": [
         "SharePoint"
     ],
@@ -32,6 +32,12 @@
         "alt": ""
     }],
     "authors": [
+     {
+        "gitHubAccount": "sympmarc",
+        "company": "Sympraxis Consulting",
+        "pictureUrl": "https://github.com/sympmarc.png",
+        "name": "Marc D Anderson"
+    },
     {
         "gitHubAccount": "Tanddant",
         "company": "",


### PR DESCRIPTION
Adapted @Tanddant's script to work on the Content Type Hub for centralized modernization.