### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docfx-generate.yml
+++ b/.github/workflows/docfx-generate.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   docfx:
+    permissions:
+      contents: write
     # The type of runner that the job will run on
     # Note temporary patch - https://github.com/actions/runner-images/issues/10636
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pnp/script-samples/security/code-scanning/19](https://github.com/pnp/script-samples/security/code-scanning/19)

In general, to fix this kind of issue you add an explicit `permissions:` block either at the top level of the workflow (so it applies to all jobs) or inside the specific job, granting only the scopes actually required. For this workflow, the only clear need is to read and write repository contents so that the `EndBug/add-and-commit@v6` step can push to `gh-pages`. Other steps (checkout, setup-dotnet, running scripts) work with `contents: read` or do not depend on `GITHUB_TOKEN` permissions directly.

The best minimal fix without changing existing behavior is to add a `permissions:` block to the `docfx` job, just under `docfx:` (or under `runs-on:`), specifying `contents: write`. This limits the `GITHUB_TOKEN` for this job while not affecting other workflows in the repository. No imports or external dependencies are required, only a small YAML change in `.github/workflows/docfx-generate.yml` around lines 10–15.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
