### PR TITLE
Updated PnP PowerShell cmdlet in "Export all flows in environment" script

### DIFF
--- a/scripts/flow-export-all-flows-in-environment/README.md
+++ b/scripts/flow-export-all-flows-in-environment/README.md
@@ -15,7 +15,7 @@ This script will get all flows in your default environment and export them as bo
 ```powershell
 $environmentName = "Personal Productivity"
 
-$FlowEnv = Get-PnPFlowEnvironment | Where-Object { $_.Properties.DisplayName -eq $environmentName }
+$FlowEnv = Get-PnPPowerPlatformEnvironment | Where-Object { $_.Properties.DisplayName -eq $environmentName }
 
 Write-Host "Getting All Flows in $environmentName Environment"
 $flows = Get-PnPFlow -Environment $FlowEnv -AsAdmin #Remove -AsAdmin Parameter to only target Flows you have permission to access
@@ -23,7 +23,6 @@ $flows = Get-PnPFlow -Environment $FlowEnv -AsAdmin #Remove -AsAdmin Parameter t
 Write-Host "Found $($flows.Count) Flows to export..."
 
 foreach ($flow in $flows) {
-
     Write-Host "Exporting as ZIP & JSON... $($flow.Properties.DisplayName)"
     $filename = $flow.Properties.DisplayName.Replace(" ", "")
     $timestamp = Get-Date -Format "yyyymmddhhmmss"
@@ -31,7 +30,6 @@ foreach ($flow in $flows) {
     $exportPath = $exportPath.Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
     Export-PnPFlow -Environment $FlowEnv -Identity $flow.Name -PackageDisplayName $flow.Properties.DisplayName -AsZipPackage -OutPath "$exportPath.zip" -Force
     Export-PnPFlow -Environment $FlowEnv -Identity $flow.Name | Out-File "$exportPath.json"
-
 }
 
 ```
@@ -41,13 +39,14 @@ foreach ($flow in $flows) {
 ## Source Credit
 
 Added PnP PowerShell version from [PnP.PowerShell + Bonus Script: Export all Flows using PnP.PowerShell](https://www.leonarmston.com/2021/01/testing-out-the-new-power-automate-flow-commands-in-pnp-powershell-bonus-script-export-all-flows-using-pnp-powershell/)
+
 ## Contributors
 
 | Author(s) |
 |-----------|
 | Luise Freese |
 | [Leon Armston](https://github.com/LeonArmston) |
+| [Smita Nachan](https://github.com/SmitaNachan) |
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]
 <img src="https://m365-visitor-stats.azurewebsites.net/script-samples/scripts/flow-export-all-flows-in-environment" aria-hidden="true" />
-

--- a/scripts/flow-export-all-flows-in-environment/assets/sample.json
+++ b/scripts/flow-export-all-flows-in-environment/assets/sample.json
@@ -7,7 +7,7 @@
     "title": "Export all flows in environment",
     "url": "https://pnp.github.io/script-samples/flow-export-all-flows-in-environment/README.html",
     "creationDateTime": "2021-03-12",
-    "updateDateTime": "2021-11-18",
+    "updateDateTime": "2026-05-04",
     "shortDescription": "This script will get all flows in your default environment and export them for importing back into Power Automate",
     "longDescription": null,
     "products": [
@@ -18,12 +18,13 @@
     ],
     "tags": [
       "Export-PnPFlow",
-      "Get-PnPFlow"
+      "Get-PnPFlow",
+      "Get-PnPPowerPlatformEnvironment"
     ],
     "metadata": [
       {
         "key": "PNP-POWERSHELL",
-        "value": "1.8.0"
+        "value": "3.1.0"
       }
     ],
     "thumbnails": [
@@ -47,6 +48,12 @@
         "gitHubAccount": "LuiseFreese",
         "company": "Luise Freese",
         "pictureUrl": "https://avatars.githubusercontent.com/u/49960482?v=4"
+      },
+      {
+        "name": "Smita Nachan",
+        "gitHubAccount": "SmitaNachan",
+        "company": "",
+        "pictureUrl": "https://github.com/SmitaNachan.png"
       }
     ],
     "references": [


### PR DESCRIPTION
Updated the script [Export all flows in environment](https://pnp.github.io/script-samples/flow-export-all-flows-in-environment/README.html?tabs=pnpps) to use `Get-PnPPowerPlatformEnvironment` instead of the deprecated `Get-PnPFlowEnvironment` for retrieving the environment.
