### PR TITLE
Fix: never flag Enterprise tier as over quota (boosted-tenant false positives)

### DIFF
--- a/scripts/onedrive-overquota-report/README.md
+++ b/scripts/onedrive-overquota-report/README.md
@@ -29,6 +29,8 @@ The expected quota is derived from the **highest-tier OneDrive service plan** in
 
 Unlicensed users with a OneDrive (e.g. retained offboarded accounts) are flagged as over quota whenever `StorageUsed > 0`.
 
+**Enterprise tier is never flagged as over quota.** Enterprise users sit at the top of the license stack and cannot exceed their true entitlement — any usage above 5 TB is legitimate (tenant-level OneDrive storage boost up to 25 TB, an admin-raised quota, or a Microsoft Support exception). Their usage still appears in the report, but `OverQuota` is always `False` for Enterprise rows.
+
 ### Scan modes
 
 | Mode | How invoked | Speed | Data freshness | Notes |
@@ -947,7 +949,14 @@ foreach ($site in $allODBSites) {
 
     $quotaInfo       = Get-ExpectedQuotaTier -LicenseDetails $licenseDetails
     $expectedQuotaMB = $quotaInfo.LimitMB
-    $isOver          = $site.StorageUsedMB -gt $expectedQuotaMB
+
+    # Enterprise users are at the top of the license stack , they cannot exceed
+    # their true entitlement. If they show over 5 TB, it's because the tenant has
+    # OneDrive storage boost enabled (legitimately permitting up to 25 TB) or
+    # Microsoft Support has granted an exception. Flagging Enterprise users
+    # produces false positives, so we never mark them as over quota.
+    $isOver          = if ($quotaInfo.Tier -eq 'Enterprise') { $false }
+                       else { $site.StorageUsedMB -gt $expectedQuotaMB }
     $overByMB        = if ($isOver) { $site.StorageUsedMB - $expectedQuotaMB } else { 0 }
     $skuList         = ($licenseDetails | ForEach-Object { $_.skuPartNumber }) -join ", "
 

--- a/scripts/onedrive-overquota-report/assets/sample.json
+++ b/scripts/onedrive-overquota-report/assets/sample.json
@@ -9,7 +9,7 @@
       "Microsoft Graph-based report that identifies OneDrive users whose storage usage exceeds their license-based expected quota."
     ],
     "creationDateTime": "2026-05-22",
-    "updateDateTime": "2026-05-22",
+    "updateDateTime": "2026-05-29",
     "products": [
       "Graph"
     ],


### PR DESCRIPTION
## What this changes

Updates the `onedrive-overquota-report` sample so users with an Enterprise OneDrive service plan (E3/E5/A3/A5/Plan 2) are never marked `OverQuota = True`, regardless of how much storage they're using.

## Why

Enterprise sits at the top of the OneDrive for Business license stack — users at this tier cannot exceed their true entitlement. Any usage above 5 TB is legitimate:

- Tenant has OneDrive storage boost enabled (per-user ceiling rises to 25 TB), OR
- Admin has manually raised the per-user quota via `Set-SPOSite -StorageQuota`, OR
- Microsoft Support has granted a case-by-case exception.

In all of these cases the storage was granted on purpose. The previous behavior flagged these users as over quota, which produced false positives on boosted tenants and confused admins reviewing the report.

## Changes in this PR

- `scripts/onedrive-overquota-report/README.md`
  - Embedded script: `$isOver` now short-circuits to `$false` when `$quotaInfo.Tier -eq 'Enterprise'`.
  - Prose: added a note under the Quota tiers table documenting the new behavior.