### PR TITLE
Fix: preserve non-ASCII characters in spo-request-pnp-reindex-user-profile (#878)

### DIFF
--- a/scripts/spo-request-pnp-reindex-user-profile/README.md
+++ b/scripts/spo-request-pnp-reindex-user-profile/README.md
@@ -183,6 +183,7 @@ Sample first appeared on [https://github.com/wobba/SPO-Trigger-Reindex](https://
 | Valeras Narbutas |
 | Mikael Svenson |
 | [Todd Klindt](https://www.toddklindt.com)|
+| Juan Andres Rodriguez |
 
 
 [!INCLUDE [DISCLAIMER](../../docfx/includes/DISCLAIMER.md)]

--- a/scripts/spo-request-pnp-reindex-user-profile/README.md
+++ b/scripts/spo-request-pnp-reindex-user-profile/README.md
@@ -130,7 +130,7 @@ Request-PnPReindexUserProfile -url https://contoso.sharepoint.com/sites/IT -Docu
         
         $filename = "upa-batch-trigger";
 
-        Set-Content -Path "$tempPath\$filename.txt" -value $json
+        Set-Content -Path "$tempPath\$filename.txt" -value $json -Encoding UTF8
 
         Write-Output "Kicking off import job - Please be patient and allow for 4-24h before profiles are updates in search.`n`nDo NOT re-run because you are impatient!"
 

--- a/scripts/spo-request-pnp-reindex-user-profile/assets/sample.json
+++ b/scripts/spo-request-pnp-reindex-user-profile/assets/sample.json
@@ -9,7 +9,7 @@
       ""
     ],
     "creationDateTime": "2022-07-28",
-    "updateDateTime": "2024-01-09",
+    "updateDateTime": "2026-06-24",
     "products": [
       "SharePoint"
     ],
@@ -39,6 +39,12 @@
       }
     ],
     "authors": [
+      {
+        "gitHubAccount": "juandresrodca",
+        "company": "",
+        "pictureUrl": "https://github.com/juandresrodca.png",
+        "name": "Juan Andres Rodriguez"
+      },
       {
         "gitHubAccount": "ValerasNarbutas",
         "company": "",


### PR DESCRIPTION
## Summary
Fixes #878. The reindex script wrote its JSON batch file with `Set-Content` and no `-Encoding`, which defaults to ANSI on Windows PowerShell. Non-ASCII characters in the Department field were therefore corrupted before the file was uploaded to the UPA bulk-import job.

## Change
Added `-Encoding UTF8` to the `Set-Content` call so the import preserves the original characters.

This matches the fix validated by @DavorSukeri in the issue thread.